### PR TITLE
Robust way to find CUDA includes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,40 @@
+import os
+import glob
+import shutil
 import logging
-
 import setuptools
+from pathlib import Path
 from setuptools import setup
 
 logger = logging.getLogger(__name__)
 
+# copy & modify from torch/utils/cpp_extension.py
+def _find_cuda_home():
+    """Find the CUDA install path."""
+    # Guess #1
+    cuda_home = os.environ.get('CUDA_HOME') or os.environ.get('CUDA_PATH')
+    if cuda_home is None:
+        # Guess #2
+        nvcc_path = shutil.which("nvcc")
+        if nvcc_path is not None:
+            cuda_home = os.path.dirname(os.path.dirname(nvcc_path))
+        else:
+            # Guess #3
+            cuda_home = '/usr/local/cuda'
+    return cuda_home
+
+cuda_home = Path(_find_cuda_home())
+include_dirs = [
+    str(cuda_home.resolve() / 'targets/x86_64-linux/include'),
+]
 setup(
     name='torch_memory_saver',
     version='0.0.4',
     ext_modules=[setuptools.Extension(
         'torch_memory_saver_cpp',
         ['csrc/torch_memory_saver.cpp'],
-        extra_compile_args=['-I/usr/local/cuda/include'],
-        extra_link_args=['-lcuda'],
+        include_dirs=include_dirs,
+        libraries=['cuda']
     )],
     python_requires=">=3.9",
     packages=['torch_memory_saver'],


### PR DESCRIPTION
The original setup.py only looks at '/usr/local/cuda/include' for CUDA toolkit includes. However, under many conditions CUDA toolkits may not be installed at the regular location but data disk or somewhere else. 

The community usually suggest setting `CUDA_HOME` and ['CFLAGS'](https://github.com/pytorch/pytorch/blob/79e8a692574f0aa0e95a63e31c16a6c7e5ef9383/setup.py#L19) (yes but not `CXXFLAGS` or `CPPFLAGS`) to help find these includes. In recent update of `pip` or `setuptools` specifiying env `CFLAGS` seems do not pass these arguments to compiler any more. So I choose to only the more regular `CUDA_HOME` way here.