### PR TITLE
Support Mulitple Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,17 @@ TODO:
 - [x] Publish to pypi
 - [ ] More tests and infra
 - [ ] Documentation
+
+
+## Development
+
+```bash
+pip install -e .
+```
+
+An `torch_memory_saver_cpp.abi3.so` will be built under `build/` folder.
+
+You can use this command for testing:
+```bash
+LD_PRELOAD=/home/jobuser/torch_memory_saver/torch_memory_saver_cpp.abi3.so python examples/simple.py
+```

--- a/csrc/torch_memory_saver.cpp
+++ b/csrc/torch_memory_saver.cpp
@@ -136,7 +136,7 @@ public:
         CUDAUtils::cu_mem_set_access(*ptr, size, device);
 
         {
-            const std::lock_guard <std::mutex> lock(allocator_metadata_mutex_);
+            const std::lock_guard<std::mutex> lock(allocator_metadata_mutex_);
             allocation_metadata_.emplace(*ptr, _AllocationMetadata{size, device, allocHandle});
         }
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -8,12 +8,19 @@ logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 
 from torch_memory_saver import TorchMemorySaver
 
+import os
+
 memory_saver = TorchMemorySaver()
 
-normal_tensor = torch.full((1_000_000_000,), 100, dtype=torch.uint8, device='cuda')
+normal_tensor = torch.full((1_000_000,), 100, dtype=torch.uint8, device='cuda')
 
 with memory_saver.region():
-    pauseable_tensor = torch.full((1_000_000_000,), 100, dtype=torch.uint8, device='cuda')
+    pauseable_tensor = torch.full((10_000_000_000,), 100, dtype=torch.uint8, device='cuda')
+
+# Get the virtual address
+original_address = pauseable_tensor.data_ptr()
+print(f"Tensor virtual address: 0x{original_address:x}")
+os.system("nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits")
 
 print(f'{normal_tensor=} {pauseable_tensor=}')
 
@@ -21,11 +28,18 @@ print('sleep...')
 time.sleep(3)
 
 memory_saver.pause()
+os.system("nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits")
 
 print('sleep...')
 time.sleep(3)
 
 memory_saver.resume()
+os.system("nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits")
+
+new_address = pauseable_tensor.data_ptr()
+print(f"Tensor virtual address: 0x{new_address:x}")
+
+assert original_address == new_address, 'Tensor virtual address should be the same'
 
 print('sleep...')
 time.sleep(3)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def _get_platform_architecture():
         try:
             uname_output = subprocess.check_output(["uname", "-a"], encoding="utf-8")
             if "tegra" in uname_output:
-                return f"{"tegra"}-{host_arch}"
+                return f"tegra-{host_arch}"
         except Exception as e:
             print(f"[warn] Failed to run uname: {e}")
 


### PR DESCRIPTION

## Support Mulitple Instance

## Why

vLLM has supported Multi-Stage Awake for vllm engine: https://github.com/vllm-project/vllm/issues/15254

But in SGLang, we are using `torch_memory_saver` for holding the model weight and KV Cache virtual address (to make sure CUDA Graph works across different rollouts)

And `torch_memory_saver` is a singleton, which make it hard for SGLang to support Multi-Stage Awake which is critical in RL use case


## More context:
https://github.com/vllm-project/vllm/issues/15254 
https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/scheduler.py#L2111 
https://github.com/sgl-project/sglang/blob/27e327b415cfd009ce1cf747b3fc0a1bbe7ee15b/test/srt/test_release_memory_occupation.py#L21 
https://github.com/fzyzcjy/torch_memory_saver?tab=readme-ov-file 
https://github.com/sgl-project/sglang/issues/2542#issuecomment-2563641647 
https://github.com/sgl-project/sglang/issues/2583 
https://github.com/vllm-project/vllm/blob/main/vllm/worker/worker.py#L145 
https://github.com/sgl-project/sglang/issues/6367 