### PR TITLE
Fix CUDA Graph Example by removing torch.cuda.MemPool()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 *.so
 .idea
 dist
+**/__pycache__/

--- a/examples/cuda_graph.py
+++ b/examples/cuda_graph.py
@@ -12,7 +12,7 @@ memory_saver = TorchMemorySaver()
 dummy_tensor_size = (5, 100_000_000,)
 
 
-def _ptr(x):
+def get_hex_ptr(x):
     assert isinstance(x, torch.Tensor)
     return hex(x.data_ptr())
 
@@ -25,7 +25,7 @@ class KVCache:
         with memory_saver.region():
             # or model weights, etc
             self.kv_buffer = torch.full(dummy_tensor_size, value, dtype=torch.float32, device='cuda')
-        print(f'create_buffers {_ptr(self.kv_buffer)=}')
+        print(f'create_buffers {get_hex_ptr(self.kv_buffer)=}')
 
     def clear_buffers(self):
         del self.kv_buffer
@@ -58,7 +58,7 @@ def run():
     cache = KVCache()
     static_input = torch.zeros((5,), dtype=torch.float32, device='cuda')
     static_output = torch.zeros((5,), dtype=torch.float32, device='cuda')
-    print(f'{_ptr(static_input)=} {_ptr(static_output)=}')
+    print(f'{get_hex_ptr(static_input)=} {get_hex_ptr(static_output)=}')
 
     def fn():
         nonlocal static_output
@@ -107,7 +107,7 @@ def run():
     memory_saver.resume()
 
     dummy = torch.zeros((3,), device='cuda')
-    print(f'{_ptr(dummy)=}')
+    print(f'{get_hex_ptr(dummy)=}')
 
     # cache.create_buffers(2)
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import platform
 import setuptools
 from setuptools import setup
+import subprocess
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ def _get_platform_architecture():
         try:
             uname_output = subprocess.check_output(["uname", "-a"], encoding="utf-8")
             if "tegra" in uname_output:
-                return f"{"tegra"}-{host_arch}"
+                return f"tegra-{host_arch}"
         except Exception as e:
             print(f"[warn] Failed to run uname: {e}")
 


### PR DESCRIPTION
## Motivation

When we run:
```
pip install -e . && LD_PRELOAD=/home/jobuser/torch_memory_saver/torch_memory_saver_cpp.abi3.so python examples/cuda_graph.py
```

<details>
<summary>It will fail with following error trace</summary>

```
create_buffers get_hex_ptr(self.kv_buffer)='0xa02000000'
get_hex_ptr(static_input)='0x786389a00000' get_hex_ptr(static_output)='0x786389a00200'
with torch.cuda.stream(s) execute fn
with torch.cuda.graph(g) execute fn
replay #1
static_output=tensor(101., device='cuda:0')
torch.cuda.empty_cache()
sleep...
call memory_saver.pause
sleep...
when kv cache is released, we can allocate *other* big tensors
sleep...
other_big_tensor=tensor([0, 0, 0,  ..., 0, 0, 0], device='cuda:0', dtype=torch.uint8)
sleep...
call memory_saver.resume
get_hex_ptr(dummy)='0x786389a00200'
replay #2
static_output=tensor(202., device='cuda:0')
sleep...
dummy=tensor([0., 0., 0.], device='cuda:0')
terminate called after throwing an instance of 'c10::Error'
  what():  CUDA error: invalid argument
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with TORCH_USE_CUDA_DSA to enable device-side assertions.

Exception raised from c10_cuda_check_implementation at /pytorch/c10/cuda/CUDAException.cpp:43 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x98 (0x7866dd3156c8 in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libc10.so)
frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 0xdc (0x7866dd2a93b2 in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libc10.so)
frame #2: c10::cuda::c10_cuda_check_implementation(int, char const*, char const*, int, bool) + 0x3f5 (0x7866dd3de5b5 in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libc10_cuda.so)
frame #3: <unknown function> + 0x21ada (0x7866dd3a7ada in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libc10_cuda.so)
frame #4: <unknown function> + 0x22420 (0x7866dd3a8420 in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libc10_cuda.so)
frame #5: <unknown function> + 0x3ab81 (0x7866dd3c0b81 in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libc10_cuda.so)
frame #6: c10::cuda::MemPool::~MemPool() + 0x1c8 (0x7866dd3a9ff8 in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libc10_cuda.so)
frame #7: <unknown function> + 0x38161a (0x786700b8861a in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libtorch_python.so)
frame #8: <unknown function> + 0xc16e84 (0x78670141de84 in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libtorch_python.so)
frame #9: <unknown function> + 0x38baea (0x786700b92aea in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libtorch_python.so)
frame #10: <unknown function> + 0x38c131 (0x786700b93131 in /home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/lib/libtorch_python.so)
<omitting python frames>
frame #20: <unknown function> + 0x2e57d (0x786706bed57d in /usr/lib64/libc.so.6)
frame #21: __libc_start_main + 0x80 (0x786706bed630 in /usr/lib64/libc.so.6)

Aborted (core dumped)
```

</details>


## Root Cause: 

PyTorch's memory pool (`torch.cuda.use_mem_pool`) was managing memory allocated by our custom CUDA allocator. When `TorchMemorySaver` performed `pause()/resume()` operations that unmapped/remapped memory at the driver level, PyTorch's memory pool became unaware of these changes, leading to invalid memory state during cleanup.

## Solution
Remove PyTorch memory pool management from the `region()` context manager

