### PR TITLE
Fix `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os
 import shutil
 from pathlib import Path
 import platform
-import subprocess
 import setuptools
 from setuptools import setup
 
@@ -26,36 +25,15 @@ def _find_cuda_home():
             cuda_home = '/usr/local/cuda'
     return cuda_home
 
-def _get_platform_architecture():
-    host_arch = platform.machine()
-    if host_arch == "aarch64":
-        try:
-            uname_output = subprocess.check_output(["uname", "-a"], encoding="utf-8")
-            if "tegra" in uname_output:
-                return f"{"tegra"}-{host_arch}"
-        except Exception as e:
-            print(f"[warn] Failed to run uname: {e}")
-    return host_arch
-
 cuda_home = Path(_find_cuda_home())
-arch = platform.machine()
-SYSTEM_ARCH_TYPE = os.environ.get("SYSTEM_ARCH", _get_platform_architecture())
-
-if arch == 'aarch64':
-    if SYSTEM_ARCH_TYPE == "tegra-aarch64":
-        target_dir = 'targets/aarch64-linux'
-    else:
-        target_dir = 'targets/sbsa-linux'
-else:
-    target_dir = 'targets/x86_64-linux'
 
 include_dirs = [
-    str(cuda_home.resolve() / target_dir / 'include'),
+    str((cuda_home / 'include').resolve()),
 ]
 
 library_dirs = [
-    str(cuda_home.resolve() / 'lib64'),
-    str(cuda_home.resolve() / 'lib64/stubs'),
+    str((cuda_home / 'lib64').resolve()),
+    str((cuda_home / 'lib64/stubs').resolve()),
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from pathlib import Path
 import platform
+import subprocess
 import setuptools
 from setuptools import setup
 
@@ -24,7 +25,7 @@ def _find_cuda_home():
             # Guess #3
             cuda_home = '/usr/local/cuda'
     return cuda_home
-    
+
 def _get_platform_architecture():
     host_arch = platform.machine()
     if host_arch == "aarch64":
@@ -34,7 +35,6 @@ def _get_platform_architecture():
                 return f"{"tegra"}-{host_arch}"
         except Exception as e:
             print(f"[warn] Failed to run uname: {e}")
-
     return host_arch
 
 cuda_home = Path(_find_cuda_home())


### PR DESCRIPTION
Worth noting `setup.py` can be simplified by using CUDA symlinks

```diff
7d6
< import subprocess
29,39d27
< def _get_platform_architecture():
<     host_arch = platform.machine()
<     if host_arch == "aarch64":
<         try:
<             uname_output = subprocess.check_output(["uname", "-a"], encoding="utf-8")
<             if "tegra" in uname_output:
<                 return f"{"tegra"}-{host_arch}"
<         except Exception as e:
<             print(f"[warn] Failed to run uname: {e}")
<     return host_arch
<
41,50d28
< arch = platform.machine()
< SYSTEM_ARCH_TYPE = os.environ.get("SYSTEM_ARCH", _get_platform_architecture())
<
< if arch == 'aarch64':
<     if SYSTEM_ARCH_TYPE == "tegra-aarch64":
<         target_dir = 'targets/aarch64-linux'
<     else:
<         target_dir = 'targets/sbsa-linux'
< else:
<     target_dir = 'targets/x86_64-linux'
53c31
<     str(cuda_home.resolve() / target_dir / 'include'),
---
>     str((cuda_home / 'include').resolve()),
57,58c35,36
<     str(cuda_home.resolve() / 'lib64'),
<     str(cuda_home.resolve() / 'lib64/stubs'),
---
>     str((cuda_home / 'lib64').resolve()),
>     str((cuda_home / 'lib64/stubs').resolve()),
```