### PR TITLE
add rl example with cuda graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ torch_memory_saver.pause("type1")
 torch_memory_saver.resume("type1")
 ```
 
+### CUDA Graph Example
+
+Please refer to `rl_with_cuda_graph.py` for details.
+
+```bash
+pip install -e .
+cd examples
+bash run_rl_example.sh
+```
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ torch_memory_saver.pause("type1")
 torch_memory_saver.resume("type1")
 ```
 
-### CUDA Graph Example
+### Example of RL with CUDA Graph
 
-Please refer to `rl_with_cuda_graph.py` for details.
+Please refer to `rl_examples.py` for details.
 
 ```bash
 pip install -e .

--- a/examples/rl_example.py
+++ b/examples/rl_example.py
@@ -1,5 +1,6 @@
 """
-This example demonstrates the core functionalities of torch_memory_saver. It validates how virtual addresses
+This example demonstrates the core functionalities of torch_memory_saver, and the detailed comments act
+as a short tutorial for readers who want to understand the library. It validates how virtual addresses
 remain unchanged while physical memory is released during pause and reallocated upon resume, illustrating the
 mechanisms of pausing and resuming memory regions, the implications for data consistency, and the preservation
 of functional integrity for tensor operations and CUDA graphs.

--- a/examples/rl_example.py
+++ b/examples/rl_example.py
@@ -1,178 +1,262 @@
 import logging
 import os
 import sys
-import time
 from typing import Callable
 
 import torch
+import time
 from torch_memory_saver import torch_memory_saver
-from examples.util import print_gpu_memory_gb
+from util import print_gpu_memory_gb
 
 logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 
+# Define the size of a large tensor for simulating KV cache
+# Size: 5 * 100,000,000 * 4 bytes = 2GB
 dummy_tensor_size = (5, 100_000_000,)
 
 
 def _ptr(x):
+    """
+    Get the virtual address of a tensor.
+    
+    Virtual Address is the address that the process sees, not the actual physical memory address.
+    It needs to be mapped to actual GPU physical memory through the CUDA driver.
+    In torch_memory_saver, this virtual address remains unchanged during pause/resume operations.
+    """
     assert isinstance(x, torch.Tensor)
     return hex(x.data_ptr())
 
+
 class Model:
+    """
+    Simulate a neural network model for validating memory management of model weights.
+    
+    Validation objectives:
+    1. Whether model weights can maintain functional integrity during pause/resume operations.
+    2. Virtual address remains unchanged, but physical memory is reallocated.
+    3. Data needs to be reinitialized because physical memory content is lost.
+    """
     def __init__(self, input_size=20_480, output_size=20_480):
         self.input_size = input_size
         self.output_size = output_size
         self.create_weights()
     
     def create_weights(self):
-        with torch_memory_saver.region(tag="model_weights"):
-            self.linear = torch.nn.Linear(self.input_size, self.output_size, bias=False, device='cuda')
-            torch.nn.init.ones_(self.linear.weight)
+        """
+        Create model weights in the region managed by torch_memory_saver.
         
-        print(f'create_weights {_ptr(self.linear.weight)=}')
+        Use torch_memory_saver.region() to mark this memory allocation,
+        enabling subsequent pause/resume operations through tags.
+        """
+        with torch_memory_saver.region(tag="model_weights"):
+            # Create a large linear layer weight matrix.
+            # Size: 20480 * 20480 * 4 bytes ≈ 1.6GB
+            self.linear = torch.nn.Linear(self.input_size, self.output_size, bias=False, device='cuda')
+            torch.nn.init.ones_(self.linear.weight)  # Initialize to all ones.
+        
+        print(f'Model weights created: {_ptr(self.linear.weight)}')
     
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward propagation, returns the mean of the product of weights and input."""
         return self.linear(x).mean()
     
     def clear_weights(self):
         del self.linear
 
+
 class KVCache:
+    """
+    Simulate KV cache for validating memory management of cache data.
+    
+    Validation objectives:
+    1. Whether KV cache can maintain data consistency during pause/resume operations.
+    2. Pause/resume operations on large memory blocks (2GB).
+    3. Verify that virtual address remains unchanged while physical memory is reallocated.
+    """
     def __init__(self):
         self.create_buffers(1)
 
     def create_buffers(self, value):
+        """
+        Create KV cache in the region managed by torch_memory_saver.
+        
+        Use torch_memory_saver.region() to mark this memory allocation,
+        enabling subsequent pause/resume operations through tags.
+        """
         with torch_memory_saver.region(tag="kv_cache"):
+            # Create a large KV cache tensor.
+            # Size: 5 * 100,000,000 * 4 bytes = 2GB
             self.kv_buffer = torch.full(dummy_tensor_size, value, dtype=torch.float32, device='cuda')
-        print(f'create_buffers {_ptr(self.kv_buffer)=}')
+        print(f'KV cache created: {_ptr(self.kv_buffer)}')
 
     def clear_buffers(self):
         del self.kv_buffer
 
     def execute(self, arg: torch.Tensor) -> torch.Tensor:
+        """Execute KV cache operation, returns the combined result of input and cache data."""
         return (arg + self.kv_buffer.mean(dim=1)).mean()
 
 
 # https://pytorch.org/blog/accelerating-pytorch-with-cuda-graphs/
 def create_cuda_graph(fn: Callable):
+    """
+    Create CUDA graph for validating the impact of memory management on CUDA graphs.
+    
+    Validation objectives:
+    1. Whether CUDA graphs can still work normally after pause/resume.
+    2. The importance of virtual address remaining unchanged for CUDA graphs.
+    3. CUDA graphs can still execute correctly even when physical memory is reallocated.
+    """
     s = torch.cuda.Stream()
     s.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(s):
-        print('with torch.cuda.stream(s) execute fn')
         fn()
     torch.cuda.current_stream().wait_stream(s)
 
     g = torch.cuda.CUDAGraph()
     with torch.cuda.graph(g):
-        print('with torch.cuda.graph(g) execute fn')
         fn()
 
     return g
 
 
 def run():
+    """
+    Main test function: validate the core functionality of torch_memory_saver.
+    
+    Core concept validation:
+    
+    1. Virtual Address vs Physical Memory mapping relationship.
+       - Virtual Address remains unchanged during pause/resume operations.
+       - Physical Memory is released during pause, reallocated during resume.
+    
+    2. Pause mechanism.
+       - Disconnect the mapping from virtual address to physical memory.
+       - Release physical memory back to GPU memory pool.
+       - Keep virtual address unchanged.
+       - Accessing paused tensors will cause CUDA errors.
+    
+    3. Resume mechanism.
+       - Allocate new physical memory from GPU memory pool.
+       - Re-establish mapping from virtual address to new physical memory.
+       - Newly allocated physical memory content is undefined (usually 0).
+       - Data needs to be reinitialized.
+    
+    4. Data consistency.
+       - Data is lost during pause (physical memory is released).
+       - Data is undefined after resume (new physical memory).
+       - Data must be reset to be used normally.
+    
+    5. Functional integrity.
+       - Tensor operations can still work normally even when physical memory is reallocated.
+       - CUDA graphs can still execute correctly (because virtual address remains unchanged).
+       - Selective pause/resume functionality works normally.
+    """
+    
     cache = KVCache()
     model = Model()
+    original_kv_cache_ptr = _ptr(cache.kv_buffer)
+    original_model_weights_ptr = _ptr(model.linear.weight)
+    print(f'Original addresses - KV cache: {original_kv_cache_ptr}, Model weights: {original_model_weights_ptr}')
+    
+    # Create static input/output tensors for CUDA graphs
+    # These tensors are not managed by torch_memory_saver, addresses will change normally
     static_input = torch.zeros((20_480,), dtype=torch.float32, device='cuda')
     static_output = torch.zeros((), dtype=torch.float32, device='cuda')
-    print(f'{_ptr(static_input)=} {_ptr(static_output)=}')
 
     def fn():
+        """Function executed in CUDA graph: combine KV cache and model computation"""
         nonlocal static_output
         kv_output = cache.execute(static_input[:5])
         model_output = model.forward(static_input)
         static_output = kv_output + model_output
 
+    # Create CUDA graph
     g = create_cuda_graph(fn)
 
-    print('replay #1')
+    # First execution of CUDA graph
     static_input[...] = 100
     g.replay()
-    print(f'{static_output=}')
-    # KV: 101, Model: mean(100 * 1 * 20480) = 2,048,000
-    assert static_output == 2048101, f'{static_output=}'
+    print(f'First execution result: {static_output.item()}')
+    if static_output != 2048101:
+        raise ValueError(f'Expected 2048101, got {static_output}')
+    print("✓ CUDA graph first execution passed!")
 
-    print('torch.cuda.empty_cache()')
-    torch.cuda.empty_cache()
-
-    print('sleep...')
     time.sleep(3)
 
-    print('Before pause kv_cache')
-    print_gpu_memory_gb("Before pause kv_cache")
-
+    # Pause memory regions
+    print('\n=== Pausing memory regions ===')
+    print_gpu_memory_gb("model_weights: allocated, kv_cache: allocated")
     torch_memory_saver.pause("kv_cache")
-    print('After pause kv_cache')
-    print_gpu_memory_gb("After pause kv_cache")
-
+    print_gpu_memory_gb("model_weights: allocated, kv_cache: released")
     torch_memory_saver.pause("model_weights")
-    print('After pause model_weights')
-    print_gpu_memory_gb("After pause model_weights")
+    print_gpu_memory_gb("model_weights: released, kv_cache: released")
 
-    print('sleep...')
     time.sleep(3)
 
-    print('when kv cache and model weights are released, we can allocate *other* big tensors')
-    other_big_tensor = torch.zeros((2500_000_000,), dtype=torch.uint8, device='cuda')
-    print('sleep...')
-    time.sleep(3)
-    print(f'{other_big_tensor=}')
-    del other_big_tensor
-    torch.cuda.empty_cache()
-    print('sleep...')
-    time.sleep(3)
-
-    print('Before resume model_weights and kv_cache')
-    print_gpu_memory_gb("Before resume")
-    
+    # Resume memory regions
+    print('\n=== Resuming memory regions ===')
     torch_memory_saver.resume("model_weights")
-    print('After resume model_weights')
-    print_gpu_memory_gb("After resume model_weights")
-    
+    print_gpu_memory_gb("model_weights: resumed, kv_cache: released")
     torch_memory_saver.resume("kv_cache")
-    print('After resume kv_cache') 
-    print_gpu_memory_gb("After resume kv_cache")
+    print_gpu_memory_gb("model_weights: resumed, kv_cache: resumed")
 
-    dummy = torch.zeros((3,), device='cuda')
-    print(f'{_ptr(dummy)=}')
+    time.sleep(3)
 
+    # Verify virtual addresses remain unchanged
+    print('\n=== Virtual Address Verification ===')
+    kv_cache_ptr_after_resume = _ptr(cache.kv_buffer)
+    model_weights_ptr_after_resume = _ptr(model.linear.weight)
+    
+    kv_address_unchanged = kv_cache_ptr_after_resume == original_kv_cache_ptr
+    model_address_unchanged = model_weights_ptr_after_resume == original_model_weights_ptr
+    
+    print(f'KV cache address unchanged: {kv_address_unchanged}')
+    print(f'Model weights address unchanged: {model_address_unchanged}')
+    
+    assert kv_address_unchanged, f"KV cache virtual address changed"
+    assert model_address_unchanged, f"Model weights virtual address changed"
+    print("✓ Virtual addresses verification passed!")
+
+    time.sleep(3)
+
+    # Reinitialize data and test functionality
+    print('\n=== Testing functionality after resume ===')
     cache.kv_buffer[...] = 2
     with torch.no_grad():
         model.linear.weight[...] = 2
 
-    print('replay #2')
+    # Second execution of CUDA graph, validate functional integrity
+    # Even when physical memory is reallocated, CUDA graph can still work normally
+    # This is because virtual address remains unchanged, addresses recorded in CUDA graph are still valid
     static_input[...] = 200
     g.replay()
-    print(f'{static_output=}')
-    # KV: 202, Model: mean(200 * 2 * 20480) = 8,192,000  
-    assert static_output == 8192202, f'{static_output=}'
+    print(f'Second execution result: {static_output.item()}')
+    if static_output != 8192202:
+        raise ValueError(f'Expected 8192202, got {static_output}')
+    print("✓ CUDA graph second execution passed!")
 
-    print('sleep...')
     time.sleep(3)
 
-    print(f'{dummy=}')
-
-    print("Succeed!")
-    print("=" * 100)
-    
-    # Additional test: demonstrate selective pause/resume
-    print("\n=== Additional test: selective pause/resume ===")
-    print("Pause only kv_cache, keep model_weights active")
+    # Test selective pause/resume
+    print('\n=== Testing selective pause/resume ===')
     torch_memory_saver.pause("kv_cache")
-    print_gpu_memory_gb("Only kv_cache paused")
+    print_gpu_memory_gb("model_weights: resumed, kv_cache: released")
     
-    print("Try to access model weights (should work)")
+    # Verify model weights can still be accessed
     try:
         _ = model.linear.weight[0, 0]
-        print("Model weights access successful")
+        print("✓ Model weights access successful")
     except:
-        print("Model weights access failed")
+        print("✗ Model weights access failed")
+        raise
     
-    print("Resume kv_cache")
     torch_memory_saver.resume("kv_cache")
-    print_gpu_memory_gb("All resumed")
+    print_gpu_memory_gb("model_weights: resumed, kv_cache: resumed")
+    
+    print("✓ Selective pause/resume test passed!")
 
-    # exit this process gracefully, bypassing CUDA cleanup
-    # Checkout for more details: https://github.com/fzyzcjy/torch_memory_saver/pull/18 
+    print("\n🎉 All tests passed! torch_memory_saver is working correctly.")
     os._exit(0)
 
 

--- a/examples/rl_example.py
+++ b/examples/rl_example.py
@@ -34,7 +34,7 @@ class Model:
     Validation objectives:
     1. Whether model weights can maintain functional integrity during pause/resume operations.
     2. Virtual address remains unchanged, but physical memory is reallocated.
-    3. Data needs to be reinitialized because physical memory content is lost.
+    3. Weights need to be reinitialized because physical memory content is lost.
     """
     def __init__(self, input_size=20_480, output_size=20_480):
         self.input_size = input_size
@@ -52,12 +52,11 @@ class Model:
             # Create a large linear layer weight matrix.
             # Size: 20480 * 20480 * 4 bytes ≈ 1.6GB
             self.linear = torch.nn.Linear(self.input_size, self.output_size, bias=False, device='cuda')
-            torch.nn.init.ones_(self.linear.weight)  # Initialize to all ones.
+            torch.nn.init.ones_(self.linear.weight)
         
         print(f'Model weights created: {_ptr(self.linear.weight)}')
     
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward propagation, returns the mean of the product of weights and input."""
         return self.linear(x).mean()
     
     def clear_weights(self):
@@ -68,10 +67,7 @@ class KVCache:
     """
     Simulate KV cache for validating memory management of cache data.
     
-    Validation objectives:
-    1. Whether KV cache can maintain data consistency during pause/resume operations.
-    2. Pause/resume operations on large memory blocks (2GB).
-    3. Verify that virtual address remains unchanged while physical memory is reallocated.
+    Verify that virtual address remains unchanged while physical memory is reallocated.
     """
     def __init__(self):
         self.create_buffers(1)

--- a/examples/rl_example.py
+++ b/examples/rl_example.py
@@ -1,3 +1,11 @@
+"""
+This example demonstrates the core functionalities of torch_memory_saver. It validates how virtual addresses
+remain unchanged while physical memory is released during pause and reallocated upon resume, illustrating the
+mechanisms of pausing and resuming memory regions, the implications for data consistency, and the preservation
+of functional integrity for tensor operations and CUDA graphs.
+"""
+
+
 import logging
 import os
 import sys

--- a/examples/run_rl_example.sh
+++ b/examples/run_rl_example.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Get the absolute path of the script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/examples/run_rl_example.sh
+++ b/examples/run_rl_example.sh
@@ -3,14 +3,19 @@
 # Get the absolute path of the script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Get Python version and platform info
+PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+PLATFORM=$(python -c "import platform; print(platform.machine())")
+
 # Build the path to torch_memory_saver_cpp.abi3.so
-# Assuming it's in the build/lib.linux-x86_64-cpython-312/ directory
-SO_PATH="$SCRIPT_DIR/../build/lib.linux-x86_64-cpython-312/torch_memory_saver_cpp.abi3.so"
+SO_PATH="$SCRIPT_DIR/../build/lib.linux-${PLATFORM}-cpython-${PYTHON_VERSION//./}/torch_memory_saver_cpp.abi3.so"
 
 # Check if the .so file exists
 if [ ! -f "$SO_PATH" ]; then
     echo "Error: $SO_PATH not found!"
-    echo "Please make sure torch_memory_saver is built correctly."
+    echo "Python version: $PYTHON_VERSION"
+    echo "Platform: $PLATFORM"
+    echo "Please make sure torch_memory_saver is built correctly for your Python version."
     exit 1
 fi
 

--- a/examples/run_rl_example.sh
+++ b/examples/run_rl_example.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Get the absolute path of the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Build the path to torch_memory_saver_cpp.abi3.so
+# Assuming it's in the build/lib.linux-x86_64-cpython-312/ directory
+SO_PATH="$SCRIPT_DIR/../build/lib.linux-x86_64-cpython-312/torch_memory_saver_cpp.abi3.so"
+
+# Check if the .so file exists
+if [ ! -f "$SO_PATH" ]; then
+    echo "Error: $SO_PATH not found!"
+    echo "Please make sure torch_memory_saver is built correctly."
+    exit 1
+fi
+
+echo "Using LD_PRELOAD=$SO_PATH"
+echo "Running rl_example.py..."
+
+# Set LD_PRELOAD environment variable and run the Python script
+LD_PRELOAD="$SO_PATH" python "$SCRIPT_DIR/rl_example.py" 

--- a/examples/run_rl_example.sh
+++ b/examples/run_rl_example.sh
@@ -1,3 +1,5 @@
+# TODO make a general script
+
 # Get the absolute path of the script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
I updated an example for `torch_memory_savor` for RL.

Core concept validation:

1. Virtual Address vs Physical Memory mapping relationship.
   - Virtual Address remains unchanged during pause/resume operations.
   - Physical Memory is released during pause, reallocated during resume.

2. Pause mechanism.
   - Disconnect the mapping from virtual address to physical memory.
   - Release physical memory back to GPU memory pool.
   - Keep virtual address unchanged.
   - Accessing paused tensors will cause CUDA errors.

3. Resume mechanism.
   - Allocate new physical memory from GPU memory pool.
   - Re-establish mapping from virtual address to new physical memory.
   - Newly allocated physical memory content is undefined (usually 0).
   - Data needs to be reinitialized.

4. Data consistency.
   - Data is lost during pause (physical memory is released).
   - Data is undefined after resume (new physical memory).
   - Data must be reset to be used normally.

5. Functional integrity.
   - Tensor operations can still work normally even when physical memory is reallocated.
   - CUDA graphs can still execute correctly (because virtual address remains unchanged).
   - Selective pause/resume functionality works normally.
