### PR TITLE
[BugFix] support GDR if possible

### DIFF
--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -184,6 +184,13 @@ namespace CUDAUtils {
         prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
         prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
         prop.location.id = device;
+
+        int flag = 0;
+        CURESULT_CHECK(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED, device));
+        if (flag) {  // support GPUDirect RDMA if possible
+            prop.allocFlags.gpuDirectRDMACapable = 1;
+        }
+
         CURESULT_CHECK(cuMemCreate(alloc_handle, size, &prop, 0));
     }
 


### PR DESCRIPTION
The current `master` version of `torch_memory_saver` does not support GPUDirect RDMA transport.
`ibv_reg_mr` will fail and report `bad address` when using memory saver.

This PR fix this bug.