### PR TITLE
fix cudart deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ def _create_ext_modules(platform):
             str((platform_home / 'lib64').resolve()),
             str((platform_home / 'lib64/stubs').resolve()),
         ]
-        libraries = ['cuda']
+        libraries = ['cuda', 'cudart']
         platform_macros = [('USE_CUDA', '1')]
         extra_compile_args = ['-std=c++17', '-O3']
     


### PR DESCRIPTION
This PR fixed the following error:

```
torch_memory_saver_hook_mode_preload.abi3.so: undefined symbol: cudaMallocHost
```