### PR TITLE
fix: add headers to pypi tar

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include csrc/*.h


### PR DESCRIPTION
**Problem:** The 0.0.9rc1 PyPI source distribution was missing C++ header files (`*.h`), causing build failures when users tried to install from source. This occurred because the codebase was refactored from a single `torch_memory_saver.cpp` file to multiple `.cpp`/`.h` files, but only `.cpp` files were being included in the sdist tarball.

**Solution:** Added `MANIFEST.in` to explicitly include all header files from `csrc/`.

**Proof:**

Before (0.0.9rc1 without fix):
```
csrc/api_forwarder.cpp  ✓
csrc/core.cpp          ✓
csrc/entrypoint.cpp    ✓
csrc/*.h               ✗ MISSING
```

After (with MANIFEST.in):
```bash
$ tar -tzf dist/torch_memory_saver-0.0.9rc1.tar.gz | grep csrc/
torch_memory_saver-0.0.9rc1/csrc/
torch_memory_saver-0.0.9rc1/csrc/api_forwarder.cpp
torch_memory_saver-0.0.9rc1/csrc/api_forwarder.h  ← Fixed
torch_memory_saver-0.0.9rc1/csrc/core.cpp
torch_memory_saver-0.0.9rc1/csrc/core.h           ← Fixed
torch_memory_saver-0.0.9rc1/csrc/entrypoint.cpp
torch_memory_saver-0.0.9rc1/csrc/macro.h          ← Fixed
torch_memory_saver-0.0.9rc1/csrc/utils.h          ← Fixed
```

All required header files are now included in the source distribution.

---

Testing locally right now