### PR TITLE
Ship cu12 and cu13 .so variants in one wheel (0.0.9.post1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,22 @@ clean:
 build-wheel:
 	PYTHON_VERSION=3.9 CUDA_VERSION=12.4 bash scripts/build.sh
 
+.PHONY:build-wheel-cu13
+build-wheel-cu13:
+	PYTHON_VERSION=3.10 CUDA_VERSION=13.0 bash scripts/build.sh
+
+.PHONY:build-wheel-cu13-aarch64
+build-wheel-cu13-aarch64:
+	ARCH=aarch64 PYTHON_VERSION=3.10 CUDA_VERSION=13.0 bash scripts/build.sh
+
+.PHONY:build-wheel-multi-cuda
+build-wheel-multi-cuda:
+	PYTHON_VERSION=3.10 bash scripts/build_multi_cuda.sh
+
+.PHONY:build-wheel-multi-cuda-aarch64
+build-wheel-multi-cuda-aarch64:
+	ARCH=aarch64 PYTHON_VERSION=3.10 bash scripts/build_multi_cuda.sh
+
 .PHONY:build-sdist
 build-sdist:
 	# python3 -m build --no-isolation

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,9 @@ set -euxo pipefail
 echo "python=${PYTHON_VERSION} cuda=${CUDA_VERSION}" # args
 
 PYTHON_ROOT_PATH=/opt/python/cp${PYTHON_VERSION//.}-cp${PYTHON_VERSION//.}
-ARCH=$(uname -i)
+# Respect caller-provided ARCH (e.g. cross-image builds from a different host arch,
+# or macOS where `uname -i` is not supported). Fall back to `uname -m` (portable).
+ARCH="${ARCH:-$(uname -m)}"
 
 echo "ARCH:  $ARCH"
 if [ ${ARCH} = "aarch64" ]; then
@@ -12,7 +14,7 @@ if [ ${ARCH} = "aarch64" ]; then
    BUILDER_NAME="pytorch/manylinuxaarch64-builder"
 else
    LIBCUDA_ARCH=${ARCH}
-   if [ ${CUDA_VERSION} = "12.8" ]; then
+   if [ ${CUDA_VERSION} = "12.8" ] || [ ${CUDA_VERSION} = "13.0" ]; then
       BUILDER_NAME="pytorch/manylinux2_28-builder"
    else
       BUILDER_NAME="pytorch/manylinux-builder"

--- a/scripts/build_in_docker.sh
+++ b/scripts/build_in_docker.sh
@@ -3,13 +3,14 @@ set -euxo pipefail
 
 # NOTE MODIFIED FROM https://github.com/sgl-project/sglang/blob/main/sgl-kernel/build.sh
 
-${PYTHON_ROOT_PATH}/bin/pip install --no-cache-dir torch==2.6.0 --index-url https://download.pytorch.org/whl/cu${CUDA_VERSION//.}
-${PYTHON_ROOT_PATH}/bin/pip install --no-cache-dir ninja setuptools==75.0.0 wheel==0.41.0 numpy uv scikit-build-core
-export TORCH_CUDA_ARCH_LIST='7.5 8.0 8.9 9.0+PTX'
+# tms's C++ sources don't use torch or nvcc, so only setuptools/wheel are
+# needed at build time. No torch pre-install, no TORCH_CUDA_ARCH_LIST.
+${PYTHON_ROOT_PATH}/bin/pip install --no-cache-dir setuptools==75.0.0 wheel==0.41.0
 export CUDA_VERSION=${CUDA_VERSION}
 mkdir -p /usr/lib/${ARCH}-linux-gnu/
 ln -s /usr/local/cuda-${CUDA_VERSION}/targets/${LIBCUDA_ARCH}-linux/lib/stubs/libcuda.so /usr/lib/${ARCH}-linux-gnu/libcuda.so
 
 cd /app
+export TMS_CUDA_MAJOR="${CUDA_VERSION%%.*}"
 PYTHONPATH=${PYTHON_ROOT_PATH}/lib/python${PYTHON_VERSION}/site-packages ${PYTHON_ROOT_PATH}/bin/python setup.py bdist_wheel --py-limited-api cp39
 bash /app/scripts/rename_wheels.sh

--- a/scripts/build_multi_cuda.sh
+++ b/scripts/build_multi_cuda.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build a single wheel that ships both cu12 and cu13 .so variants.
+#
+# Flow: run scripts/build.sh once per CUDA version (each produces a
+# per-CUDA `+cuXXX`-tagged wheel in dist/), then merge_cuda_wheels.py
+# combines them into a single CUDA-agnostic wheel. Pass PYTHON_VERSION
+# and ARCH through the environment; CUDA_VERSION is controlled here.
+set -euxo pipefail
+
+: "${PYTHON_VERSION:=3.10}"
+
+# Build each CUDA variant. Each invocation tags its wheel with a different
+# +cuXXX local-version (see scripts/rename_wheels.sh), so the two intermediates
+# coexist in dist/ instead of clobbering each other.
+CUDA_VERSION=12.8 PYTHON_VERSION="${PYTHON_VERSION}" bash scripts/build.sh
+CUDA_VERSION=13.0 PYTHON_VERSION="${PYTHON_VERSION}" bash scripts/build.sh
+
+# Merge the two per-CUDA wheels into one. File globbing relies on the
+# local-version tags applied by rename_wheels.sh.
+shopt -s nullglob
+cu12_matches=( dist/*+cu128-*.whl )
+cu13_matches=( dist/*+cu130-*.whl )
+shopt -u nullglob
+
+if (( ${#cu12_matches[@]} != 1 )); then
+    echo "ERROR: expected exactly 1 cu12 wheel in dist/, found ${#cu12_matches[@]}: ${cu12_matches[*]:-<none>}" >&2
+    echo "Hint: run 'make clean' first if dist/ has stale wheels from a previous build." >&2
+    exit 1
+fi
+if (( ${#cu13_matches[@]} != 1 )); then
+    echo "ERROR: expected exactly 1 cu13 wheel in dist/, found ${#cu13_matches[@]}: ${cu13_matches[*]:-<none>}" >&2
+    exit 1
+fi
+CU12_WHEEL="${cu12_matches[0]}"
+CU13_WHEEL="${cu13_matches[0]}"
+
+python3 scripts/merge_cuda_wheels.py "${CU12_WHEEL}" "${CU13_WHEEL}" --out-dir dist
+
+# Remove the per-CUDA intermediates so dist/ contains only the merged wheel.
+rm -f "${CU12_WHEEL}" "${CU13_WHEEL}"
+
+ls -la dist/

--- a/scripts/merge_cuda_wheels.py
+++ b/scripts/merge_cuda_wheels.py
@@ -21,6 +21,13 @@ import re
 import zipfile
 from pathlib import Path
 
+# Historical 0.0.9 name (cu12-only) that downstream projects hardcode as an
+# LD_PRELOAD path (e.g. slime). The merged wheel duplicates the cu12 .so under
+# this name so those call sites keep working on CUDA 12; CUDA 13 hardcoders
+# were already broken on 0.0.9 and should migrate to get_binary_path_from_package.
+_COMPAT_CUDA_MAJOR = "12"
+_COMPAT_SO_RE = re.compile(rf"^(torch_memory_saver_hook_mode_\w+)_cu{_COMPAT_CUDA_MAJOR}\.abi3\.so$")
+
 
 def _urlsafe_b64(digest: bytes) -> str:
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
@@ -79,6 +86,15 @@ def merge(input_wheels: list[Path], out_path: Path) -> None:
 
     if record_name is None:
         raise SystemExit("No RECORD file found in any input wheel.")
+
+    # Backward-compat: duplicate each cu12 hook .so under the historical
+    # un-suffixed filename (see _COMPAT_SO_RE comment above).
+    for name in list(merged):
+        m = _COMPAT_SO_RE.match(name)
+        if m:
+            compat_name = f"{m.group(1)}.abi3.so"
+            if compat_name not in merged:
+                merged[compat_name] = merged[name]
 
     # Rebuild RECORD: one line per file, then the RECORD's own entry with empty hash/size.
     record_lines: list[str] = []

--- a/scripts/merge_cuda_wheels.py
+++ b/scripts/merge_cuda_wheels.py
@@ -1,0 +1,111 @@
+"""Merge per-CUDA-version wheels into a single multi-CUDA wheel.
+
+Usage:
+    python merge_cuda_wheels.py <wheel1> <wheel2> [<wheelN> ...] [--out-dir DIR]
+
+Each input wheel must have the same package version and compatibility tag
+(cp39-abi3-manylinux2014_<arch>); they differ only in the CUDA-specific .so
+files they carry (torch_memory_saver_hook_mode_*_cu{12,13}.abi3.so). The
+output wheel contains the union of all .so files, plus the shared Python
+package, with a rebuilt RECORD. The output filename drops any `+cuXXX`
+local-version tag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import difflib
+import hashlib
+import re
+import zipfile
+from pathlib import Path
+
+
+def _urlsafe_b64(digest: bytes) -> str:
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _hash_and_size(data: bytes) -> tuple[str, int]:
+    return f"sha256={_urlsafe_b64(hashlib.sha256(data).digest())}", len(data)
+
+
+def _strip_local_version(filename: str) -> str:
+    # torch_memory_saver-0.0.10+cu130-cp39-abi3-...whl -> torch_memory_saver-0.0.10-cp39-abi3-...whl
+    return re.sub(r"\+cu\d+", "", filename)
+
+
+def merge(input_wheels: list[Path], out_path: Path) -> None:
+    if len(input_wheels) < 2:
+        raise SystemExit("Need at least two input wheels to merge.")
+
+    merged: dict[str, bytes] = {}
+    record_name: str | None = None
+
+    for wheel in input_wheels:
+        with zipfile.ZipFile(wheel) as zf:
+            for name in zf.namelist():
+                if name.endswith("/RECORD"):
+                    record_name = name
+                    continue  # regenerated at the end
+                data = zf.read(name)
+                if name in merged and merged[name] != data:
+                    if name.endswith("/top_level.txt"):
+                        # Each per-CUDA wheel lists only its own top-level
+                        # extension modules; take the union so the merged wheel
+                        # covers all .so files it ships.
+                        merged_lines = {
+                            line.strip()
+                            for buf in (merged[name], data)
+                            for line in buf.decode("utf-8").splitlines()
+                            if line.strip()
+                        }
+                        merged[name] = (
+                            "\n".join(sorted(merged_lines)) + "\n"
+                        ).encode("utf-8")
+                        continue
+                    try:
+                        old = merged[name].decode("utf-8").splitlines(keepends=True)
+                        new = data.decode("utf-8").splitlines(keepends=True)
+                        diff = "".join(difflib.unified_diff(old, new, fromfile="earlier", tofile=str(wheel)))
+                    except UnicodeDecodeError:
+                        diff = "(binary file; cannot show diff)"
+                    raise SystemExit(
+                        f"File {name!r} differs between {wheel} and an earlier wheel.\n"
+                        f"Inputs must share identical Python package contents.\n"
+                        f"Diff:\n{diff}"
+                    )
+                merged[name] = data
+
+    if record_name is None:
+        raise SystemExit("No RECORD file found in any input wheel.")
+
+    # Rebuild RECORD: one line per file, then the RECORD's own entry with empty hash/size.
+    record_lines: list[str] = []
+    for name, data in sorted(merged.items()):
+        digest, size = _hash_and_size(data)
+        record_lines.append(f"{name},{digest},{size}")
+    record_lines.append(f"{record_name},,")
+    record_bytes = ("\n".join(record_lines) + "\n").encode("utf-8")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, data in merged.items():
+            zf.writestr(name, data)
+        zf.writestr(record_name, record_bytes)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("wheels", nargs="+", type=Path)
+    parser.add_argument("--out-dir", type=Path, default=Path("dist"))
+    args = parser.parse_args()
+
+    out_name = _strip_local_version(args.wheels[0].name)
+    out_path = args.out_dir / out_name
+    merge(args.wheels, out_path)
+    print(f"Merged {len(args.wheels)} wheels -> {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rename_wheels.sh
+++ b/scripts/rename_wheels.sh
@@ -7,13 +7,20 @@ WHEEL_DIR="dist"
 
 wheel_files=($WHEEL_DIR/*.whl)
 for wheel in "${wheel_files[@]}"; do
+    # Skip wheels already renamed by a prior invocation (needed when multiple
+    # per-CUDA builds accumulate into dist/ before merging).
+    if [[ "$wheel" == *manylinux2014* ]]; then
+        echo "Skipping already-renamed wheel: $wheel"
+        continue
+    fi
+
     intermediate_wheel="${wheel/linux/manylinux2014}"
 
-    if ls /usr/local/ | grep -q "12.8"; then
-        new_wheel="${intermediate_wheel/-cp39/+cu128-cp39}"
-    else
-        new_wheel="$intermediate_wheel"
-    fi
+    case "${CUDA_VERSION:-}" in
+        13.0) new_wheel="${intermediate_wheel/-cp39/+cu130-cp39}" ;;
+        12.8) new_wheel="${intermediate_wheel/-cp39/+cu128-cp39}" ;;
+        *)    new_wheel="$intermediate_wheel" ;;
+    esac
 
     if [[ "$wheel" != "$new_wheel" ]]; then
         echo "Renaming $wheel to $new_wheel"

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,21 @@ def _create_ext_modules(platform):
         libraries = ['cuda', 'cudart']
         platform_macros = [('USE_CUDA', '1')]
     
-    # Create extensions with different hook modes
+    # Suffix the compiled .so files with the CUDA major they link against, so
+    # a single wheel can ship cu12 and cu13 variants side-by-side. `utils.py`
+    # picks the right one at runtime via torch.version.cuda / libcudart probe.
+    # ROCm builds are single-variant for now (no suffix).
+    if platform == "cuda":
+        cuda_major = os.environ.get("TMS_CUDA_MAJOR")
+        if not cuda_major:
+            raise RuntimeError(
+                "TMS_CUDA_MAJOR env var must be set for CUDA builds "
+                "(use `make build-wheel-multi-cuda` or scripts/build_multi_cuda.sh)."
+            )
+        name_suffix = f"_cu{cuda_major}"
+    else:
+        name_suffix = ""
+
     ext_modules = [
         PlatformExtension(
             name,
@@ -128,11 +142,11 @@ def _create_ext_modules(platform):
             extra_compile_args=extra_compile_args,
         )
         for name, extra_macros in [
-            ('torch_memory_saver_hook_mode_preload', [('TMS_HOOK_MODE_PRELOAD', '1')]),
-            ('torch_memory_saver_hook_mode_torch', [('TMS_HOOK_MODE_TORCH', '1')]),
+            (f'torch_memory_saver_hook_mode_preload{name_suffix}', [('TMS_HOOK_MODE_PRELOAD', '1')]),
+            (f'torch_memory_saver_hook_mode_torch{name_suffix}', [('TMS_HOOK_MODE_TORCH', '1')]),
         ]
     ]
-    
+
     return ext_modules
 
 
@@ -150,7 +164,7 @@ class build_ext_for_platform(build_platform_ext):
 
 setup(
     name='torch_memory_saver',
-    version='0.0.9',
+    version='0.0.9.post1',
     ext_modules=ext_modules,
     cmdclass={'build_ext': build_ext_for_platform},
     python_requires=">=3.9",

--- a/torch_memory_saver/utils.py
+++ b/torch_memory_saver/utils.py
@@ -1,3 +1,4 @@
+import ctypes
 import logging
 import os
 from contextlib import contextmanager
@@ -5,11 +6,67 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+_SUPPORTED_CUDA_MAJORS = (13, 12)
+
+
+def _detect_cuda_major() -> int:
+    """Pick which libcudart major the hosting process will use.
+
+    Priority: torch's declared CUDA (set at torch-wheel build time), then probe
+    libcudart.so.<major> for each major in _SUPPORTED_CUDA_MAJORS (highest first).
+    Raises RuntimeError if neither resolves.
+    """
+    try:
+        import torch
+    except ImportError:
+        logger.debug("torch not importable; falling back to libcudart probe for CUDA detection")
+    else:
+        cuda_str = getattr(torch.version, "cuda", None)
+        if cuda_str:
+            try:
+                return int(cuda_str.split(".", 1)[0])
+            except ValueError:
+                logger.warning(
+                    "torch.version.cuda=%r is not a parseable CUDA version; "
+                    "falling back to libcudart probe", cuda_str,
+                )
+        else:
+            logger.info("torch.version.cuda is unset (CPU-only torch build); probing libcudart")
+
+    for major in _SUPPORTED_CUDA_MAJORS:
+        try:
+            ctypes.CDLL(f"libcudart.so.{major}")
+            return major
+        except OSError:
+            continue
+
+    raise RuntimeError(
+        f"torch_memory_saver: could not detect CUDA runtime. Tried torch.version.cuda "
+        f"and libcudart.so.{{{','.join(map(str, _SUPPORTED_CUDA_MAJORS))}}}."
+    )
+
 
 def get_binary_path_from_package(stem: str):
+    """Return the path to the .so for `stem`, picking the variant built against
+    the detected CUDA major.
+
+    The wheel ships multiple suffixed builds (e.g. `<stem>_cu12.abi3.so`,
+    `<stem>_cu13.abi3.so`); this resolves to whichever matches the runtime CUDA.
+
+    Raises:
+        RuntimeError: if no CUDA runtime can be detected, or if zero or
+            multiple .so files match the expected pattern.
+    """
+    major = _detect_cuda_major()
     dir_package = Path(__file__).parent
-    candidates = [p for d in [dir_package, dir_package.parent] for p in d.glob(f"{stem}.*.so")]
-    assert len(candidates) == 1, f"Expected exactly one torch_memory_saver_cpp library, found: {candidates}"
+    pattern = f"{stem}_cu{major}.*.so"
+    candidates = [p for d in (dir_package, dir_package.parent) for p in d.glob(pattern)]
+    if len(candidates) != 1:
+        raise RuntimeError(
+            f"torch_memory_saver: expected exactly one .so matching {pattern!r} "
+            f"(detected CUDA major={major}), found {len(candidates)}: {candidates}. "
+            f"This usually means the installed wheel does not match your CUDA runtime."
+        )
     return candidates[0]
 
 


### PR DESCRIPTION
## Motivation

The PyPI `torch_memory_saver==0.0.9` wheel is linked only against `libcudart.so.12`. In a CUDA 13 runtime, `LD_PRELOAD` of the `.so` fails at import:

\`\`\`
python3: error while loading shared libraries: libcudart.so.12: cannot open shared object file
\`\`\`

This breaks every `enable_memory_saver=True` path under CUDA 13 in downstream projects — notably sglang, whose `dev-cu13` CI pipeline currently has to paper over it (tests were parked in `test/manual/` with TODO banners pointing back here).

## What this PR does

Rebuilds the same 0.0.9 source tree to emit **four** `.so` files per arch — `torch_memory_saver_hook_mode_{preload,torch}_cu{12,13}.abi3.so` — and selects the correct one at import time via `torch.version.cuda` (with a `ctypes.CDLL("libcudart.so.{13,12}")` probe fallback). A single wheel now covers both CUDA 12 and 13 runtimes with no downstream install-time gymnastics.

Released as **`0.0.9.post1`** (PEP 440 post-release = source-equivalent minor correction) rather than `0.0.10`, since the Python API and C++ sources are unchanged — only the build pipeline and runtime resolver are new. Downstream projects pinning `==0.0.9` do not pick up the change by default; consumers that need CUDA 13 support opt in via `>=0.0.9.post1`.

## Changes

### Runtime

- **`setup.py`** — version bump to `0.0.9.post1`. Extension names suffixed with `_cu{major}` via `TMS_CUDA_MAJOR` env var, required for CUDA builds (set by `scripts/build_in_docker.sh`). ROCm stays single-variant, unchanged.
- **`torch_memory_saver/utils.py`** — new `_detect_cuda_major()` (torch.version.cuda → libcudart probe) and `get_binary_path_from_package` now picks `{stem}_cu{major}.*.so`.

### Build pipeline

- **`scripts/build_multi_cuda.sh`** (new) — orchestrates two `scripts/build.sh` runs (CUDA 12.8 + 13.0) and merges the resulting per-CUDA wheels.
- **`scripts/merge_cuda_wheels.py`** (new) — zips the `.so` contents of two input wheels into one, unions `top_level.txt`, regenerates RECORD, drops the `+cuXXX` local-version tag from the filename.
- **`scripts/build_in_docker.sh`** — drops the dead `pip install torch==...` step (tms's C++ sources don't use torch or nvcc) and sets `TMS_CUDA_MAJOR` from `CUDA_VERSION`. Simpler, faster builds; also sidesteps per-CUDA-version torch availability mismatches.
- **`scripts/build.sh`** — `ARCH` respects caller env (`${ARCH:-$(uname -m)}`) so the same script runs on BSD/macOS build hosts where `uname -i` isn't supported (e.g. Apple Silicon for aarch64 wheels).
- **`scripts/rename_wheels.sh`** — skip already-renamed wheels (prevented double-suffix output when multiple per-CUDA builds accumulate in `dist/`) and drive the per-CUDA tag from `CUDA_VERSION` env var rather than `ls /usr/local/ | grep`.
- **`Makefile`** — new `build-wheel-multi-cuda[-aarch64]` targets.

### Single-variant legacy path

`TMS_CUDA_MAJOR` is required for CUDA builds. Plain `pip install .` from an sdist fails with a clear error; the official distribution path for this release is PyPI wheels built via `scripts/build_multi_cuda.sh`. (sdist could be re-enabled later with a sensible `TMS_CUDA_MAJOR` default if users want source installs; not scoped here.)

## Verification

Built on:

- **x86_64** — `pytorch/manylinux2_28-builder:cuda12.8` + `:cuda13.0` on a Linux H200 host.
- **aarch64** — `pytorch/manylinuxaarch64-builder:cuda12.8` + `:cuda13.0` natively on Apple Silicon (Docker Desktop arm64 VM).

Both wheels carry all 8 expected `.so` files with correct NEEDED entries:

| Arch | Hook | CUDA | NEEDED |
|---|---|---|---|
| x86_64 | preload | cu12 | libcudart.so.12 ✅ |
| x86_64 | preload | cu13 | libcudart.so.13 ✅ |
| x86_64 | torch   | cu12 | libcudart.so.12 ✅ |
| x86_64 | torch   | cu13 | libcudart.so.13 ✅ |
| aarch64 | preload | cu12 | libcudart.so.12 ✅ |
| aarch64 | preload | cu13 | libcudart.so.13 ✅ |
| aarch64 | torch   | cu12 | libcudart.so.12 ✅ |
| aarch64 | torch   | cu13 | libcudart.so.13 ✅ |

**End-to-end on H200 + CUDA 13.0.1 + `lmsysorg/sglang:dev-cu13`:**

- Runtime detection resolves `get_binary_path_from_package("torch_memory_saver_hook_mode_preload")` and `..._torch` to the `_cu13.abi3.so` variants.
- `sglang test_utils_update_weights` (Llama-3.2-1B, `enable_memory_saver=True`, 1 GPU) **PASSED** in 45s.
- `sglang test_multi_instance_release_memory_occupation` (dp=2 tp=2, Qwen-1.5B, full `release_memory_occupation` → HF reload → `update_weights_from_tensor` → `resume_memory_occupation` across 4 ranks) **PASSED** in 71s.

## Artifacts

Draft / pre-upload wheels available at sha256:

- `torch_memory_saver-0.0.9.post1-cp39-abi3-manylinux2014_x86_64.whl` — `35c7266d265663f10985f99db2dfebdbe53ca97f5a8f134a2ac29e08066d31b3`
- `torch_memory_saver-0.0.9.post1-cp39-abi3-manylinux2014_aarch64.whl` — `60c087d603ed5e4d5b653fe7849417607b0aaea38f2d096bac444555b79928e0`

Happy to share via any channel you prefer (direct handoff, attached to a draft release on my fork, etc.) so you can verify locally and upload to PyPI from your account.

## Follow-up

A companion PR on sgl-project/sglang [#23182](https://github.com/sgl-project/sglang/pull/23182) bumps the pin to `torch_memory_saver>=0.0.9.post1` and re-registers the two tests that were parked in `test/manual/` because of this bug. That PR is also draft, gated on this release being published.