### PR TITLE
Fix ROCm binary resolution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ def _create_ext_modules(platform):
     # Suffix the compiled .so files with the CUDA major they link against, so
     # a single wheel can ship cu12 and cu13 variants side-by-side. `utils.py`
     # picks the right one at runtime via torch.version.cuda / libcudart probe.
-    # ROCm builds are single-variant for now (no suffix).
+    # ROCm builds are single-variant for now and use unsuffixed binaries.
     if platform == "cuda":
         cuda_major = os.environ.get("TMS_CUDA_MAJOR")
         if not cuda_major:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,34 @@
+import sys
+from types import SimpleNamespace
+
+from torch_memory_saver import utils
+
+
+def _fake_torch(cuda=None, hip=None):
+    return SimpleNamespace(version=SimpleNamespace(cuda=cuda, hip=hip))
+
+
+def test_get_binary_path_from_package_uses_unsuffixed_rocm_binary(monkeypatch, tmp_path):
+    stem = "torch_memory_saver_hook_mode_preload"
+    package_dir = tmp_path / "torch_memory_saver"
+    package_dir.mkdir()
+    binary = tmp_path / f"{stem}.abi3.so"
+    binary.touch()
+
+    monkeypatch.setattr(utils, "__file__", str(package_dir / "utils.py"))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(hip="7.2.0"))
+
+    assert utils.get_binary_path_from_package(stem) == binary
+
+
+def test_get_binary_path_from_package_keeps_cuda_suffix_selection(monkeypatch, tmp_path):
+    stem = "torch_memory_saver_hook_mode_preload"
+    package_dir = tmp_path / "torch_memory_saver"
+    package_dir.mkdir()
+    binary = tmp_path / f"{stem}_cu12.abi3.so"
+    binary.touch()
+
+    monkeypatch.setattr(utils, "__file__", str(package_dir / "utils.py"))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(cuda="12.9"))
+
+    assert utils.get_binary_path_from_package(stem) == binary

--- a/torch_memory_saver/utils.py
+++ b/torch_memory_saver/utils.py
@@ -9,6 +9,15 @@ logger = logging.getLogger(__name__)
 _SUPPORTED_CUDA_MAJORS = (13, 12)
 
 
+def _is_rocm_torch() -> bool:
+    try:
+        import torch
+    except ImportError:
+        return False
+
+    return bool(getattr(torch.version, "hip", None))
+
+
 def _detect_cuda_major() -> int:
     """Pick which libcudart major the hosting process will use.
 
@@ -48,24 +57,32 @@ def _detect_cuda_major() -> int:
 
 def get_binary_path_from_package(stem: str):
     """Return the path to the .so for `stem`, picking the variant built against
-    the detected CUDA major.
+    the detected GPU runtime.
 
-    The wheel ships multiple suffixed builds (e.g. `<stem>_cu12.abi3.so`,
-    `<stem>_cu13.abi3.so`); this resolves to whichever matches the runtime CUDA.
+    CUDA wheels ship multiple suffixed builds (e.g. `<stem>_cu12.abi3.so`,
+    `<stem>_cu13.abi3.so`). ROCm builds ship an unsuffixed binary
+    (e.g. `<stem>.abi3.so`).
 
     Raises:
-        RuntimeError: if no CUDA runtime can be detected, or if zero or
+        RuntimeError: if no GPU runtime can be detected, or if zero or
             multiple .so files match the expected pattern.
     """
-    major = _detect_cuda_major()
     dir_package = Path(__file__).parent
-    pattern = f"{stem}_cu{major}.*.so"
+
+    if _is_rocm_torch():
+        pattern = f"{stem}.*.so"
+        runtime_desc = "ROCm/HIP torch"
+    else:
+        major = _detect_cuda_major()
+        pattern = f"{stem}_cu{major}.*.so"
+        runtime_desc = f"CUDA major={major}"
+
     candidates = [p for d in (dir_package, dir_package.parent) for p in d.glob(pattern)]
     if len(candidates) != 1:
         raise RuntimeError(
             f"torch_memory_saver: expected exactly one .so matching {pattern!r} "
-            f"(detected CUDA major={major}), found {len(candidates)}: {candidates}. "
-            f"This usually means the installed wheel does not match your CUDA runtime."
+            f"(detected {runtime_desc}), found {len(candidates)}: {candidates}. "
+            f"This usually means the installed wheel does not match your GPU runtime."
         )
     return candidates[0]
 


### PR DESCRIPTION
## Summary
- Detect ROCm/HIP torch builds before probing CUDA runtimes.
- Resolve unsuffixed ROCm torch_memory_saver shared libraries while preserving CUDA _cuXX lookup.
- Add resolver tests covering ROCm and CUDA paths.

## Tests
- python -m pytest test/test_utils.py test/test_configure_subprocess.py -q