### PR TITLE
feat(hooks): add pluggable hook modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ The mode can be chosen by:
 torch_memory_saver.hook_mode = "torch"
 ```
 
+Custom implementations can register a lazy factory:
+
+```python
+from torch_memory_saver import torch_memory_saver, register_hook_mode
+
+register_hook_mode("custom", lambda: CustomMemorySaver(), uses_preload=False)
+torch_memory_saver.hook_mode = "custom"
+```
+
+The implementation must provide `region`, `cuda_graph`, `pause`, and `resume`
+(plus any other facade method you call). Select the mode before first use;
+`configure_subprocess()` skips the `LD_PRELOAD` setup for modes registered
+with `uses_preload=False`.
+
 ### Example of RL with CUDA Graph
 
 Please refer to `rl_example.py` for details.

--- a/torch_memory_saver/__init__.py
+++ b/torch_memory_saver/__init__.py
@@ -1,5 +1,17 @@
-from .entrypoint import TorchMemorySaver
-from .hooks.mode_preload import configure_subprocess
+from contextlib import contextmanager
+
+from .entrypoint import TorchMemorySaver, register_hook_mode
+from .hooks import mode_preload as _mode_preload
 
 # Global singleton
 torch_memory_saver = TorchMemorySaver()
+
+
+@contextmanager
+def configure_subprocess():
+    if not torch_memory_saver._uses_preload():
+        yield
+        return
+
+    with _mode_preload.configure_subprocess():
+        yield

--- a/torch_memory_saver/entrypoint.py
+++ b/torch_memory_saver/entrypoint.py
@@ -6,7 +6,7 @@ import logging
 import os
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Optional
+from typing import Any, Callable, Dict, NamedTuple, Optional
 import torch
 
 from .binary_wrapper import BinaryWrapper
@@ -17,10 +17,32 @@ logger = logging.getLogger(__name__)
 _TAG_DEFAULT = "default"
 
 
+class _HookModeRegistration(NamedTuple):
+    factory: Callable[[], Any]
+    uses_preload: bool
+
+
+_HOOK_MODE_REGISTRY: Dict[str, _HookModeRegistration] = {}
+
+
+def register_hook_mode(name: str, factory: Callable[[], Any], *, uses_preload: bool = True) -> None:
+    """Register a process-global lazy factory for a hook mode.
+
+    Registered implementations must provide ``region``, ``cuda_graph``,
+    ``pause``, and ``resume`` (plus any other facade method the caller uses).
+    Factories are process-global and are not serialized with saver instances,
+    so registration must run in every process (e.g. under multiprocessing
+    spawn) before first use.
+    """
+    if name in _HOOK_MODE_REGISTRY:
+        raise ValueError(f"Hook mode {name!r} is already registered")
+    _HOOK_MODE_REGISTRY[name] = _HookModeRegistration(factory=factory, uses_preload=uses_preload)
+
+
 class TorchMemorySaver:
     def __init__(self):
         self._impl_ctor_kwargs = {}
-        self._impl: Optional[_TorchMemorySaverImpl] = None
+        self._impl: Optional[Any] = None
 
     @contextmanager
     def region(self, tag: str = _TAG_DEFAULT, enable_cpu_backup: bool = False):
@@ -70,8 +92,11 @@ class TorchMemorySaver:
         raise AttributeError
 
     @hook_mode.setter
-    def hook_mode(self, hook_mode: HookMode):
-        assert self._impl_ctor_kwargs is not None, "Cannot configure after initialization"
+    def hook_mode(self, hook_mode: str):
+        if self._impl is not None:
+            raise RuntimeError("Cannot configure after initialization")
+        if hook_mode not in _HOOK_MODE_REGISTRY:
+            raise ValueError(f"Unknown hook mode {hook_mode!r}")
         self._impl_ctor_kwargs["hook_mode"] = hook_mode
 
     @property
@@ -90,8 +115,22 @@ class TorchMemorySaver:
     def _ensure_initialized(self):
         if self._impl is not None:
             return
-        self._impl = _TorchMemorySaverImpl(**self._impl_ctor_kwargs)
-        del self._impl_ctor_kwargs
+        self._impl = self._registration().factory()
+
+    def _uses_preload(self) -> bool:
+        return self._registration().uses_preload
+
+    def _registration(self) -> _HookModeRegistration:
+        hook_mode = self._impl_ctor_kwargs.get("hook_mode", "preload")
+        try:
+            return _HOOK_MODE_REGISTRY[hook_mode]
+        except KeyError:
+            # e.g. a pickled saver arriving in a process that never ran the
+            # mode's register_hook_mode() call
+            raise RuntimeError(
+                f"Hook mode {hook_mode!r} is not registered in this process; "
+                "call register_hook_mode() before first use"
+            ) from None
 
 
 class _TorchMemorySaverImpl:
@@ -199,3 +238,9 @@ def _sanity_checks():
         raise RuntimeError(
             "TorchMemorySaver is disabled for the current process because expandable_segments is not supported yet."
         )
+
+
+register_hook_mode("preload", _TorchMemorySaverImpl, uses_preload=True)
+# uses_preload=True preserves the previously unconditional configure_subprocess()
+# LD_PRELOAD setup; the torch-mode allocator itself loads via dlopen.
+register_hook_mode("torch", lambda: _TorchMemorySaverImpl(hook_mode="torch"), uses_preload=True)


### PR DESCRIPTION
Closes #77 (pluggable memory-saver implementations) — the `torch_memory_saver` piece of the GPU Memory Service integration proposed in sgl-project/sglang#27310.

- `register_hook_mode(name, factory, uses_preload=...)` registers a lazily constructed custom implementation, selected through the existing `hook_mode` setter. Factories are process-global and resolved on first use; the builtin `preload`/`torch` modes are registered the same way and behave exactly as before.
- The package-level `configure_subprocess()` now consults the selected mode's `uses_preload` flag and skips the `LD_PRELOAD` setup for modes that do not use the preload hook (both builtins keep it, preserving current behavior).
- Selecting an unknown mode, re-registering a name, or using a mode never registered in the current process (e.g. a subprocess that skipped registration) fails with a descriptive error.
