### PR TITLE
feat: disk backup backend, spill paused allocations to node-local disk

### DIFF
--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -3,73 +3,8 @@
 #include "macro.h"
 #include "api_forwarder.h"
 
-#include <algorithm>
-#include <cstdlib>
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/types.h>
-
-TorchMemorySaver::TorchMemorySaver() {
-    const char* dir = std::getenv("TMS_DISK_BACKUP_DIR");
-    disk_backup_dir_ = (dir != nullptr) ? std::string(dir) : std::string("/tmp");
-
-    const char* chunk_mb = std::getenv("TMS_DISK_BACKUP_CHUNK_MB");
-    size_t mb = (chunk_mb != nullptr) ? std::strtoull(chunk_mb, nullptr, 10) : 256;
-    if (mb == 0) mb = 256;
-    disk_chunk_bytes_ = mb * 1024ull * 1024ull;
-}
-
-void TorchMemorySaver::ensure_disk_staging_() {
-    if (disk_staging_ == nullptr) {
-        CUDA_ERROR_CHECK(cudaMallocHost(&disk_staging_, disk_chunk_bytes_));
-        SIMPLE_CHECK(disk_staging_ != nullptr, "failed to allocate pinned disk staging buffer");
-    }
-}
-
-void TorchMemorySaver::disk_offload_(void* ptr, AllocationMetadata& metadata) {
-    ensure_disk_staging_();
-
-    if (metadata.disk_fd < 0) {
-        metadata.disk_path = disk_backup_dir_ + "/tms_" + std::to_string((long)getpid())
-            + "_" + std::to_string(disk_backup_counter_++) + ".bin";
-        metadata.disk_fd = open(metadata.disk_path.c_str(), O_RDWR | O_CREAT, 0600);
-        SIMPLE_CHECK(metadata.disk_fd >= 0, "failed to open disk backup file");
-        int fret = posix_fallocate(metadata.disk_fd, 0, (off_t) metadata.size);
-        SIMPLE_CHECK(fret == 0, "posix_fallocate on disk backup file failed");
-    }
-
-    size_t offset = 0;
-    while (offset < metadata.size) {
-        size_t n = std::min(disk_chunk_bytes_, metadata.size - offset);
-        CUDA_ERROR_CHECK(cudaMemcpy(disk_staging_, (uint8_t*) ptr + offset, n, cudaMemcpyDeviceToHost));
-        size_t written = 0;
-        while (written < n) {
-            ssize_t w = pwrite(metadata.disk_fd, (uint8_t*) disk_staging_ + written, n - written, (off_t)(offset + written));
-            SIMPLE_CHECK(w > 0, "pwrite to disk backup file failed");
-            written += (size_t) w;
-        }
-        offset += n;
-    }
-}
-
-void TorchMemorySaver::disk_reload_(void* ptr, AllocationMetadata& metadata) {
-    ensure_disk_staging_();
-    SIMPLE_CHECK(metadata.disk_fd >= 0, "disk backup fd invalid on resume (was it ever paused?)");
-
-    size_t offset = 0;
-    while (offset < metadata.size) {
-        size_t n = std::min(disk_chunk_bytes_, metadata.size - offset);
-        size_t got = 0;
-        while (got < n) {
-            ssize_t r = pread(metadata.disk_fd, (uint8_t*) disk_staging_ + got, n - got, (off_t)(offset + got));
-            SIMPLE_CHECK(r > 0, "pread from disk backup file failed");
-            got += (size_t) r;
-        }
-        CUDA_ERROR_CHECK(cudaMemcpy((uint8_t*) ptr + offset, disk_staging_, n, cudaMemcpyHostToDevice));
-        offset += n;
-    }
-    // fd stays open for the next pause.
-}
+TorchMemorySaver::TorchMemorySaver()
+    : disk_backend_(compute_disk_backup_dir_from_env(), compute_disk_chunk_bytes_from_env()) {}
 
 TorchMemorySaver &TorchMemorySaver::instance() {
     static TorchMemorySaver instance;
@@ -77,7 +12,12 @@ TorchMemorySaver &TorchMemorySaver::instance() {
 }
 
 cudaError_t TorchMemorySaver::malloc(void **ptr, CUdevice device, size_t size, const std::string& tag, const bool enable_cpu_backup, const bool enable_disk_backup) {
+    // Enforce here, not only in the Python layer: an assert is stripped under
+    // python -O and bypassed by direct C-API / env-var use.
+    SIMPLE_CHECK(!(enable_cpu_backup && enable_disk_backup),
+                 "cpu_backup and disk_backup are mutually exclusive");
 #if TMS_ROCM_LEGACY_CHUNKED
+    SIMPLE_CHECK(!enable_disk_backup, "disk backup is not supported on the ROCm 6.x legacy chunked path");
     return ROCmHIPImplementation::rocm_malloc(ptr, device, size, tag, enable_cpu_backup, allocation_metadata_, allocator_metadata_mutex_);
 
 #else
@@ -111,7 +51,7 @@ cudaError_t TorchMemorySaver::malloc(void **ptr, CUdevice device, size_t size, c
         allocation_metadata_.emplace(
             *ptr,
             AllocationMetadata{size, device, tag, AllocationState::ACTIVE, enable_cpu_backup, nullptr,
-                               enable_disk_backup, -1, std::string(), allocHandle}
+                               enable_disk_backup, DiskBackupSlot{}, allocHandle}
         );
     }
 
@@ -153,10 +93,8 @@ cudaError_t TorchMemorySaver::free(void *ptr) {
         metadata.cpu_backup = nullptr;
     }
 
-    if (metadata.enable_disk_backup && metadata.disk_fd >= 0) {
-        close(metadata.disk_fd);
-        unlink(metadata.disk_path.c_str());
-        metadata.disk_fd = -1;
+    if (metadata.enable_disk_backup) {
+        disk_backend_.release(metadata.disk);
     }
 
 #ifdef TMS_DEBUG_LOG
@@ -201,7 +139,7 @@ void TorchMemorySaver::pause(const std::string& tag) {
             // TODO may use cudaMemcpyAsync if needed
             CUDA_ERROR_CHECK(cudaMemcpy(metadata.cpu_backup, ptr, metadata.size, cudaMemcpyDeviceToHost));
         } else if (metadata.enable_disk_backup) {
-            disk_offload_(ptr, metadata);
+            disk_backend_.offload(ptr, metadata.size, metadata.disk);
         }
 
         CURESULT_CHECK(cuMemUnmap((CUdeviceptr) ptr, metadata.size));
@@ -260,7 +198,7 @@ void TorchMemorySaver::resume(const std::string& tag) {
             CUDA_ERROR_CHECK(cudaFreeHost(metadata.cpu_backup));
             metadata.cpu_backup = nullptr;
         } else if (metadata.enable_disk_backup) {
-            disk_reload_(ptr, metadata);
+            disk_backend_.onload(ptr, metadata.size, metadata.disk);
         }
 
 #ifdef TMS_DEBUG_LOG

--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -29,8 +29,6 @@ void TorchMemorySaver::ensure_disk_staging_() {
 void TorchMemorySaver::disk_offload_(void* ptr, AllocationMetadata& metadata) {
     ensure_disk_staging_();
 
-    // Open + preallocate the per-allocation file exactly once, then keep the fd
-    // for the allocation's lifetime and overwrite in place on every pause.
     if (metadata.disk_fd < 0) {
         metadata.disk_path = disk_backup_dir_ + "/tms_" + std::to_string((long)getpid())
             + "_" + std::to_string(disk_backup_counter_++) + ".bin";
@@ -70,7 +68,7 @@ void TorchMemorySaver::disk_reload_(void* ptr, AllocationMetadata& metadata) {
         CUDA_ERROR_CHECK(cudaMemcpy((uint8_t*) ptr + offset, disk_staging_, n, cudaMemcpyHostToDevice));
         offset += n;
     }
-    // Keep fd + file for the next pause (in-place overwrite => bounded disk usage).
+    // fd stays open for the next pause.
 }
 
 TorchMemorySaver &TorchMemorySaver::instance() {
@@ -295,9 +293,7 @@ uint8_t* TorchMemorySaver::get_cpu_backup_pointer(const uint8_t* query_gpu_ptr, 
 
         if ((ptr <= query_gpu_ptr) && (query_gpu_ptr + query_size <= ptr + total_size)) {
             const size_t offset = query_gpu_ptr - ptr;
-            // Disk-backed allocations have no CPU-resident copy to hand back;
-            // callers must fall back to the (resumed) GPU tensor. v1 does not
-            // support reading disk-backed weights while paused.
+            // Disk-backed allocations have no CPU-resident copy; callers must use the resumed GPU tensor.
             if (metadata.enable_disk_backup) {
                 return nullptr;
             }

--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -3,14 +3,82 @@
 #include "macro.h"
 #include "api_forwarder.h"
 
-TorchMemorySaver::TorchMemorySaver() {}
+#include <algorithm>
+#include <cstdlib>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+TorchMemorySaver::TorchMemorySaver() {
+    const char* dir = std::getenv("TMS_DISK_BACKUP_DIR");
+    disk_backup_dir_ = (dir != nullptr) ? std::string(dir) : std::string("/tmp");
+
+    const char* chunk_mb = std::getenv("TMS_DISK_BACKUP_CHUNK_MB");
+    size_t mb = (chunk_mb != nullptr) ? std::strtoull(chunk_mb, nullptr, 10) : 256;
+    if (mb == 0) mb = 256;
+    disk_chunk_bytes_ = mb * 1024ull * 1024ull;
+}
+
+void TorchMemorySaver::ensure_disk_staging_() {
+    if (disk_staging_ == nullptr) {
+        CUDA_ERROR_CHECK(cudaMallocHost(&disk_staging_, disk_chunk_bytes_));
+        SIMPLE_CHECK(disk_staging_ != nullptr, "failed to allocate pinned disk staging buffer");
+    }
+}
+
+void TorchMemorySaver::disk_offload_(void* ptr, AllocationMetadata& metadata) {
+    ensure_disk_staging_();
+
+    // Open + preallocate the per-allocation file exactly once, then keep the fd
+    // for the allocation's lifetime and overwrite in place on every pause.
+    if (metadata.disk_fd < 0) {
+        metadata.disk_path = disk_backup_dir_ + "/tms_" + std::to_string((long)getpid())
+            + "_" + std::to_string(disk_backup_counter_++) + ".bin";
+        metadata.disk_fd = open(metadata.disk_path.c_str(), O_RDWR | O_CREAT, 0600);
+        SIMPLE_CHECK(metadata.disk_fd >= 0, "failed to open disk backup file");
+        int fret = posix_fallocate(metadata.disk_fd, 0, (off_t) metadata.size);
+        SIMPLE_CHECK(fret == 0, "posix_fallocate on disk backup file failed");
+    }
+
+    size_t offset = 0;
+    while (offset < metadata.size) {
+        size_t n = std::min(disk_chunk_bytes_, metadata.size - offset);
+        CUDA_ERROR_CHECK(cudaMemcpy(disk_staging_, (uint8_t*) ptr + offset, n, cudaMemcpyDeviceToHost));
+        size_t written = 0;
+        while (written < n) {
+            ssize_t w = pwrite(metadata.disk_fd, (uint8_t*) disk_staging_ + written, n - written, (off_t)(offset + written));
+            SIMPLE_CHECK(w > 0, "pwrite to disk backup file failed");
+            written += (size_t) w;
+        }
+        offset += n;
+    }
+}
+
+void TorchMemorySaver::disk_reload_(void* ptr, AllocationMetadata& metadata) {
+    ensure_disk_staging_();
+    SIMPLE_CHECK(metadata.disk_fd >= 0, "disk backup fd invalid on resume (was it ever paused?)");
+
+    size_t offset = 0;
+    while (offset < metadata.size) {
+        size_t n = std::min(disk_chunk_bytes_, metadata.size - offset);
+        size_t got = 0;
+        while (got < n) {
+            ssize_t r = pread(metadata.disk_fd, (uint8_t*) disk_staging_ + got, n - got, (off_t)(offset + got));
+            SIMPLE_CHECK(r > 0, "pread from disk backup file failed");
+            got += (size_t) r;
+        }
+        CUDA_ERROR_CHECK(cudaMemcpy((uint8_t*) ptr + offset, disk_staging_, n, cudaMemcpyHostToDevice));
+        offset += n;
+    }
+    // Keep fd + file for the next pause (in-place overwrite => bounded disk usage).
+}
 
 TorchMemorySaver &TorchMemorySaver::instance() {
     static TorchMemorySaver instance;
     return instance;
 }
 
-cudaError_t TorchMemorySaver::malloc(void **ptr, CUdevice device, size_t size, const std::string& tag, const bool enable_cpu_backup) {
+cudaError_t TorchMemorySaver::malloc(void **ptr, CUdevice device, size_t size, const std::string& tag, const bool enable_cpu_backup, const bool enable_disk_backup) {
 #if TMS_ROCM_LEGACY_CHUNKED
     return ROCmHIPImplementation::rocm_malloc(ptr, device, size, tag, enable_cpu_backup, allocation_metadata_, allocator_metadata_mutex_);
 
@@ -44,7 +112,8 @@ cudaError_t TorchMemorySaver::malloc(void **ptr, CUdevice device, size_t size, c
         const std::lock_guard<std::mutex> lock(allocator_metadata_mutex_);
         allocation_metadata_.emplace(
             *ptr,
-            AllocationMetadata{size, device, tag, AllocationState::ACTIVE, enable_cpu_backup, nullptr, allocHandle}
+            AllocationMetadata{size, device, tag, AllocationState::ACTIVE, enable_cpu_backup, nullptr,
+                               enable_disk_backup, -1, std::string(), allocHandle}
         );
     }
 
@@ -84,6 +153,12 @@ cudaError_t TorchMemorySaver::free(void *ptr) {
     if (nullptr != metadata.cpu_backup) {
         CUDA_ERROR_CHECK(cudaFreeHost(metadata.cpu_backup));
         metadata.cpu_backup = nullptr;
+    }
+
+    if (metadata.enable_disk_backup && metadata.disk_fd >= 0) {
+        close(metadata.disk_fd);
+        unlink(metadata.disk_path.c_str());
+        metadata.disk_fd = -1;
     }
 
 #ifdef TMS_DEBUG_LOG
@@ -127,6 +202,8 @@ void TorchMemorySaver::pause(const std::string& tag) {
             SIMPLE_CHECK(metadata.cpu_backup != nullptr, "cpu_backup should not be nullptr");
             // TODO may use cudaMemcpyAsync if needed
             CUDA_ERROR_CHECK(cudaMemcpy(metadata.cpu_backup, ptr, metadata.size, cudaMemcpyDeviceToHost));
+        } else if (metadata.enable_disk_backup) {
+            disk_offload_(ptr, metadata);
         }
 
         CURESULT_CHECK(cuMemUnmap((CUdeviceptr) ptr, metadata.size));
@@ -184,6 +261,8 @@ void TorchMemorySaver::resume(const std::string& tag) {
             // (users may want to lazily free to reduce re-alloc time)
             CUDA_ERROR_CHECK(cudaFreeHost(metadata.cpu_backup));
             metadata.cpu_backup = nullptr;
+        } else if (metadata.enable_disk_backup) {
+            disk_reload_(ptr, metadata);
         }
 
 #ifdef TMS_DEBUG_LOG
@@ -216,6 +295,12 @@ uint8_t* TorchMemorySaver::get_cpu_backup_pointer(const uint8_t* query_gpu_ptr, 
 
         if ((ptr <= query_gpu_ptr) && (query_gpu_ptr + query_size <= ptr + total_size)) {
             const size_t offset = query_gpu_ptr - ptr;
+            // Disk-backed allocations have no CPU-resident copy to hand back;
+            // callers must fall back to the (resumed) GPU tensor. v1 does not
+            // support reading disk-backed weights while paused.
+            if (metadata.enable_disk_backup) {
+                return nullptr;
+            }
             if (metadata.state == AllocationState::ACTIVE) {
                 return nullptr;
             } else {

--- a/csrc/core.h
+++ b/csrc/core.h
@@ -27,11 +27,7 @@ struct AllocationMetadata {
     AllocationState state;
     bool enable_cpu_backup;
     void* cpu_backup;
-    // Disk backup: when enabled, the paused allocation is spilled to a fixed
-    // node-local file instead of a pinned CPU buffer. disk_fd is opened lazily
-    // on the first pause and reused for the allocation's lifetime; the file is
-    // preallocated once to `size` and overwritten in place every pause (so disk
-    // usage never grows across RL steps).
+    // Node-local backing file for disk-backed pause; fd opened lazily and reused.
     bool enable_disk_backup;
     int disk_fd;
     std::string disk_path;
@@ -71,9 +67,7 @@ private:
     TorchMemorySaver(const TorchMemorySaver&) = delete;
     TorchMemorySaver& operator=(const TorchMemorySaver&) = delete;
 
-    // Lazily allocate the shared pinned staging buffer used to stream
-    // GPU<->disk in fixed-size chunks (bounds host RAM regardless of the total
-    // amount offloaded). Callers must hold allocator_metadata_mutex_.
+    // Shared pinned staging buffer for GPU<->disk streaming. Callers must hold allocator_metadata_mutex_.
     void ensure_disk_staging_();
     void disk_offload_(void* ptr, AllocationMetadata& metadata);
     void disk_reload_(void* ptr, AllocationMetadata& metadata);

--- a/csrc/core.h
+++ b/csrc/core.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include "utils.h"
 #include "macro.h"
+#include "disk_backend.h"
 
 #if TMS_ROCM_LEGACY_CHUNKED
 #include "hardware_amd_support.h"
@@ -27,10 +28,8 @@ struct AllocationMetadata {
     AllocationState state;
     bool enable_cpu_backup;
     void* cpu_backup;
-    // Node-local backing file for disk-backed pause; fd opened lazily and reused.
     bool enable_disk_backup;
-    int disk_fd;
-    std::string disk_path;
+    DiskBackupSlot disk;
 
 #if TMS_ROCM_LEGACY_CHUNKED
     // ROCm 6.x: Chunked allocation workaround
@@ -58,7 +57,7 @@ public:
     uint8_t* get_cpu_backup_pointer(const uint8_t* query_gpu_ptr, uint64_t query_size);
     void set_disk_backup_dir(const std::string& dir) {
         const std::lock_guard<std::mutex> lock(allocator_metadata_mutex_);
-        disk_backup_dir_ = dir;
+        disk_backend_.set_dir(dir);
     }
 
 private:
@@ -67,18 +66,10 @@ private:
     TorchMemorySaver(const TorchMemorySaver&) = delete;
     TorchMemorySaver& operator=(const TorchMemorySaver&) = delete;
 
-    // Shared pinned staging buffer for GPU<->disk streaming. Callers must hold allocator_metadata_mutex_.
-    void ensure_disk_staging_();
-    void disk_offload_(void* ptr, AllocationMetadata& metadata);
-    void disk_reload_(void* ptr, AllocationMetadata& metadata);
-
     std::mutex allocator_metadata_mutex_;
     std::unordered_map<void*, AllocationMetadata> allocation_metadata_;
     std::atomic<uint64_t> memory_margin_bytes_ = 0;
 
-    // Disk-backup state (guarded by allocator_metadata_mutex_).
-    std::string disk_backup_dir_;
-    size_t disk_chunk_bytes_ = 0;
-    void* disk_staging_ = nullptr;      // pinned host, size == disk_chunk_bytes_
-    uint64_t disk_backup_counter_ = 0;  // unique suffix per allocation
+    // Guarded by allocator_metadata_mutex_.
+    DiskBackend disk_backend_;
 };

--- a/csrc/core.h
+++ b/csrc/core.h
@@ -27,6 +27,14 @@ struct AllocationMetadata {
     AllocationState state;
     bool enable_cpu_backup;
     void* cpu_backup;
+    // Disk backup: when enabled, the paused allocation is spilled to a fixed
+    // node-local file instead of a pinned CPU buffer. disk_fd is opened lazily
+    // on the first pause and reused for the allocation's lifetime; the file is
+    // preallocated once to `size` and overwritten in place every pause (so disk
+    // usage never grows across RL steps).
+    bool enable_disk_backup;
+    int disk_fd;
+    std::string disk_path;
 
 #if TMS_ROCM_LEGACY_CHUNKED
     // ROCm 6.x: Chunked allocation workaround
@@ -43,7 +51,7 @@ class TorchMemorySaver {
 public:
     static TorchMemorySaver& instance();
 
-    cudaError_t malloc(void** ptr, CUdevice device, size_t size, const std::string& tag, bool enable_cpu_backup);
+    cudaError_t malloc(void** ptr, CUdevice device, size_t size, const std::string& tag, bool enable_cpu_backup, bool enable_disk_backup);
     cudaError_t free(void *ptr);
 
     void pause(const std::string& tag);
@@ -52,6 +60,10 @@ public:
         memory_margin_bytes_.store(value);
     }
     uint8_t* get_cpu_backup_pointer(const uint8_t* query_gpu_ptr, uint64_t query_size);
+    void set_disk_backup_dir(const std::string& dir) {
+        const std::lock_guard<std::mutex> lock(allocator_metadata_mutex_);
+        disk_backup_dir_ = dir;
+    }
 
 private:
     TorchMemorySaver();
@@ -59,7 +71,20 @@ private:
     TorchMemorySaver(const TorchMemorySaver&) = delete;
     TorchMemorySaver& operator=(const TorchMemorySaver&) = delete;
 
+    // Lazily allocate the shared pinned staging buffer used to stream
+    // GPU<->disk in fixed-size chunks (bounds host RAM regardless of the total
+    // amount offloaded). Callers must hold allocator_metadata_mutex_.
+    void ensure_disk_staging_();
+    void disk_offload_(void* ptr, AllocationMetadata& metadata);
+    void disk_reload_(void* ptr, AllocationMetadata& metadata);
+
     std::mutex allocator_metadata_mutex_;
     std::unordered_map<void*, AllocationMetadata> allocation_metadata_;
     std::atomic<uint64_t> memory_margin_bytes_ = 0;
+
+    // Disk-backup state (guarded by allocator_metadata_mutex_).
+    std::string disk_backup_dir_;
+    size_t disk_chunk_bytes_ = 0;
+    void* disk_staging_ = nullptr;      // pinned host, size == disk_chunk_bytes_
+    uint64_t disk_backup_counter_ = 0;  // unique suffix per allocation
 };

--- a/csrc/disk_backend.cpp
+++ b/csrc/disk_backend.cpp
@@ -1,0 +1,161 @@
+#include "disk_backend.h"
+#include "macro.h"
+#include "utils.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <vector>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/vfs.h>
+
+#ifndef TMPFS_MAGIC
+#define TMPFS_MAGIC 0x01021994
+#endif
+#ifndef RAMFS_MAGIC
+#define RAMFS_MAGIC 0x858458f6
+#endif
+
+namespace {
+
+void pwrite_all(int fd, const void* buf, size_t n, off_t offset) {
+    size_t done = 0;
+    while (done < n) {
+        ssize_t w = pwrite(fd, (const uint8_t*) buf + done, n - done, offset + (off_t) done);
+        if (w < 0) {
+            if (errno == EINTR) continue;
+            SIMPLE_CHECK(false, (std::string("pwrite to disk backup file failed: ") + strerror(errno)).c_str());
+        }
+        SIMPLE_CHECK(w > 0, "pwrite to disk backup file returned 0");
+        done += (size_t) w;
+    }
+}
+
+void pread_all(int fd, void* buf, size_t n, off_t offset) {
+    size_t done = 0;
+    while (done < n) {
+        ssize_t r = pread(fd, (uint8_t*) buf + done, n - done, offset + (off_t) done);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            SIMPLE_CHECK(false, (std::string("pread from disk backup file failed: ") + strerror(errno)).c_str());
+        }
+        SIMPLE_CHECK(r > 0, "pread from disk backup file returned 0 (unexpected EOF)");
+        done += (size_t) r;
+    }
+}
+
+void stream_chunked(int fd, void* gpu_ptr, size_t size, void* staging, size_t chunk, bool to_disk) {
+    size_t offset = 0;
+    while (offset < size) {
+        size_t n = std::min(chunk, size - offset);
+        if (to_disk) {
+            CUDA_ERROR_CHECK(cudaMemcpy(staging, (uint8_t*) gpu_ptr + offset, n, cudaMemcpyDeviceToHost));
+            pwrite_all(fd, staging, n, (off_t) offset);
+        } else {
+            pread_all(fd, staging, n, (off_t) offset);
+            CUDA_ERROR_CHECK(cudaMemcpy((uint8_t*) gpu_ptr + offset, staging, n, cudaMemcpyHostToDevice));
+        }
+        offset += n;
+    }
+}
+
+// Drop this file's pages from the page cache (no effect on tmpfs).
+void drop_page_cache(int fd, size_t size) {
+    fsync(fd);
+    posix_fadvise(fd, 0, (off_t) size, POSIX_FADV_DONTNEED);
+}
+
+}  // namespace
+
+std::string compute_disk_backup_dir_from_env() {
+    const char* dir = std::getenv("TMS_DISK_BACKUP_DIR");
+    return (dir != nullptr) ? std::string(dir) : std::string("/tmp");
+}
+
+size_t compute_disk_chunk_bytes_from_env() {
+    const char* chunk_mb = std::getenv("TMS_DISK_BACKUP_CHUNK_MB");
+    size_t mb = (chunk_mb != nullptr) ? std::strtoull(chunk_mb, nullptr, 10) : 256;
+    if (mb == 0) mb = 256;
+    return mb * 1024ull * 1024ull;
+}
+
+DiskBackend::DiskBackend(std::string dir, size_t chunk_bytes)
+    : dir_(std::move(dir)), chunk_bytes_(chunk_bytes) {}
+
+void DiskBackend::ensure_staging_buf_() {
+    if (staging_buf_ == nullptr) {
+        CUDA_ERROR_CHECK(cudaMallocHost(&staging_buf_, chunk_bytes_));
+        SIMPLE_CHECK(staging_buf_ != nullptr, "failed to allocate pinned disk staging buffer");
+    }
+}
+
+void DiskBackend::warn_once_if_not_real_disk_() {
+    if (checked_fs_) return;
+    checked_fs_ = true;
+    struct statfs sfs;
+    if (statfs(dir_.c_str(), &sfs) == 0 &&
+        (sfs.f_type == TMPFS_MAGIC || sfs.f_type == RAMFS_MAGIC)) {
+        std::cerr << "[torch_memory_saver.cpp] WARNING: disk backup dir '" << dir_
+                  << "' is tmpfs/ramfs; backups live in RAM and do not bound host memory. "
+                  << "Point TMS_DISK_BACKUP_DIR at a real disk mount." << std::endl;
+    }
+}
+
+int DiskBackend::create_slot_file_(DiskBackupSlot& slot, size_t size) {
+    warn_once_if_not_real_disk_();
+    std::error_code ec;
+    std::filesystem::create_directories(dir_, ec);
+
+    // mkostemp: atomic unique O_RDWR|O_CREAT|O_EXCL create, mode 0600.
+    std::string tmpl = dir_ + "/tms_XXXXXX";
+    std::vector<char> buf(tmpl.begin(), tmpl.end());
+    buf.push_back('\0');
+    int fd = mkostemp(buf.data(), O_CLOEXEC);
+    SIMPLE_CHECK(fd >= 0, (std::string("failed to create disk backup file under ") + dir_
+                           + ": " + strerror(errno)).c_str());
+    slot.path.assign(buf.data());
+
+    int fret = posix_fallocate(fd, 0, (off_t) size);
+    if (fret != 0) {
+        if (fret == EOPNOTSUPP || fret == ENOTSUP || fret == EINVAL) {
+            SIMPLE_CHECK(ftruncate(fd, (off_t) size) == 0,
+                (std::string("ftruncate fallback failed on ") + slot.path + ": " + strerror(errno)).c_str());
+        } else {
+            SIMPLE_CHECK(false, (std::string("posix_fallocate failed on ") + slot.path + ": " + strerror(fret)).c_str());
+        }
+    }
+    return fd;
+}
+
+int DiskBackend::open_slot_file_(const DiskBackupSlot& slot) {
+    int fd = open(slot.path.c_str(), O_RDWR | O_CLOEXEC);
+    SIMPLE_CHECK(fd >= 0, (std::string("failed to reopen disk backup file ") + slot.path + ": " + strerror(errno)).c_str());
+    return fd;
+}
+
+void DiskBackend::offload(void* gpu_ptr, size_t size, DiskBackupSlot& slot) {
+    ensure_staging_buf_();
+    int fd = slot.path.empty() ? create_slot_file_(slot, size) : open_slot_file_(slot);
+    stream_chunked(fd, gpu_ptr, size, staging_buf_, chunk_bytes_, /*to_disk=*/true);
+    drop_page_cache(fd, size);
+    close(fd);
+}
+
+void DiskBackend::onload(void* gpu_ptr, size_t size, DiskBackupSlot& slot) {
+    ensure_staging_buf_();
+    SIMPLE_CHECK(!slot.path.empty(), "disk backup missing on resume (was it ever paused?)");
+    int fd = open_slot_file_(slot);
+    stream_chunked(fd, gpu_ptr, size, staging_buf_, chunk_bytes_, /*to_disk=*/false);
+    drop_page_cache(fd, size);
+    close(fd);
+}
+
+void DiskBackend::release(DiskBackupSlot& slot) {
+    if (!slot.path.empty()) {
+        unlink(slot.path.c_str());
+        slot.path.clear();
+    }
+}

--- a/csrc/disk_backend.h
+++ b/csrc/disk_backend.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+struct DiskBackupSlot {
+    std::string path;
+};
+
+// Spills paused GPU allocations to per-allocation files, streaming through one
+// shared pinned staging buffer. dir_ must be a real disk mount, not tmpfs.
+class DiskBackend {
+public:
+    DiskBackend(std::string dir, size_t chunk_bytes);
+
+    void set_dir(const std::string& dir) { dir_ = dir; }
+
+    void offload(void* gpu_ptr, size_t size, DiskBackupSlot& slot);
+    void onload(void* gpu_ptr, size_t size, DiskBackupSlot& slot);
+    void release(DiskBackupSlot& slot);
+
+private:
+    void ensure_staging_buf_();
+    void warn_once_if_not_real_disk_();
+    int create_slot_file_(DiskBackupSlot& slot, size_t size);
+    int open_slot_file_(const DiskBackupSlot& slot);
+
+    std::string dir_;
+    size_t chunk_bytes_;
+    void* staging_buf_ = nullptr;
+    bool checked_fs_ = false;
+};
+
+std::string compute_disk_backup_dir_from_env();
+size_t compute_disk_chunk_bytes_from_env();

--- a/csrc/entrypoint.cpp
+++ b/csrc/entrypoint.cpp
@@ -32,9 +32,21 @@ public:
         enable_cpu_backup_ = value;
     }
 
+    bool enable_disk_backup() {
+        if (!enable_disk_backup_.has_value()) {
+            enable_disk_backup_ = get_bool_env_var("TMS_INIT_ENABLE_DISK_BACKUP");
+        }
+        return enable_disk_backup_.value();
+    }
+
+    void set_enable_disk_backup(bool value) {
+        enable_disk_backup_ = value;
+    }
+
 private:
     std::optional<bool> is_interesting_region_;
     std::optional<bool> enable_cpu_backup_;
+    std::optional<bool> enable_disk_backup_;
 };
 static thread_local ThreadLocalConfig thread_local_config;
 
@@ -44,7 +56,8 @@ static thread_local ThreadLocalConfig thread_local_config;
 cudaError_t cudaMalloc(void **ptr, size_t size) {
     if (thread_local_config.is_interesting_region()) {
         return TorchMemorySaver::instance().malloc(
-            ptr, CUDAUtils::cu_ctx_get_device(), size, thread_local_config.current_tag_, thread_local_config.enable_cpu_backup());
+            ptr, CUDAUtils::cu_ctx_get_device(), size, thread_local_config.current_tag_,
+            thread_local_config.enable_cpu_backup(), thread_local_config.enable_disk_backup());
     } else {
         return APIForwarder::call_real_cuda_malloc(ptr, size);
     }
@@ -66,7 +79,8 @@ void *tms_torch_malloc(ssize_t size, int device, cudaStream_t stream) {
     SIMPLE_CHECK(thread_local_config.is_interesting_region(), "only support interesting region");
     void *ptr;
     CUDA_ERROR_CHECK(TorchMemorySaver::instance().malloc(
-        &ptr, CUDAUtils::cu_device_get(device), size, thread_local_config.current_tag_, thread_local_config.enable_cpu_backup()));
+        &ptr, CUDAUtils::cu_device_get(device), size, thread_local_config.current_tag_,
+        thread_local_config.enable_cpu_backup(), thread_local_config.enable_disk_backup()));
     return ptr;
 }
 
@@ -108,6 +122,19 @@ bool tms_get_enable_cpu_backup() {
 
 void tms_set_enable_cpu_backup(bool enable_cpu_backup) {
     thread_local_config.set_enable_cpu_backup(enable_cpu_backup);
+}
+
+bool tms_get_enable_disk_backup() {
+    return thread_local_config.enable_disk_backup();
+}
+
+void tms_set_enable_disk_backup(bool enable_disk_backup) {
+    thread_local_config.set_enable_disk_backup(enable_disk_backup);
+}
+
+void tms_set_disk_backup_dir(const char* dir) {
+    SIMPLE_CHECK(dir != nullptr, "disk backup dir should not be null");
+    TorchMemorySaver::instance().set_disk_backup_dir(std::string(dir));
 }
 
 void set_memory_margin_bytes(uint64_t value) {

--- a/csrc/hardware_amd_support.cpp
+++ b/csrc/hardware_amd_support.cpp
@@ -187,7 +187,7 @@ namespace ROCmHIPImplementation {
             const std::lock_guard<std::mutex> lock(allocator_metadata_mutex);
             allocation_metadata.emplace(
                 *ptr,
-                AllocationMetadata{size, device, tag, AllocationState::ACTIVE, enable_cpu_backup, nullptr, aligned_size, std::move(allocHandles), std::move(chunk_sizes)}
+                AllocationMetadata{size, device, tag, AllocationState::ACTIVE, enable_cpu_backup, nullptr, false, DiskBackupSlot{}, aligned_size, std::move(allocHandles), std::move(chunk_sizes)}
             );
         }
 

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ def _create_ext_modules(platform):
     sources = [
         'csrc/api_forwarder.cpp',
         'csrc/core.cpp',
+        'csrc/disk_backend.cpp',
         'csrc/entrypoint.cpp',
     ]
     

--- a/test/examples/disk_backup.py
+++ b/test/examples/disk_backup.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 import sys
 import tempfile
 
@@ -9,46 +10,61 @@ from torch_memory_saver import torch_memory_saver
 
 
 def run(hook_mode: str):
+    # Small chunk (before init) so the tensors below span many chunks.
+    os.environ["TMS_DISK_BACKUP_CHUNK_MB"] = "1"
     torch_memory_saver.hook_mode = hook_mode
     logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 
     disk_dir = tempfile.mkdtemp(prefix="tms_disk_backup_")
     print(f"disk_backup_dir={disk_dir}")
+    torch_memory_saver.set_disk_backup_dir(disk_dir)
+    try:
+        _run(disk_dir)
+    finally:
+        shutil.rmtree(disk_dir, ignore_errors=True)
+
+
+def _run(disk_dir: str):
+    chunk_bytes = 1 * 1024 * 1024
+    numel = chunk_bytes * 13 // 4 + 12345  # ~13.4 fp32 chunks: multi-chunk, non-even tail
 
     print("Allocate tensor_with_disk_backup")
-    with torch_memory_saver.region(enable_disk_backup=True, disk_backup_dir=disk_dir):
-        # Larger than the default staging chunk to exercise multi-chunk streaming.
-        tensor_with_backup = torch.full((20_000_000,), 10, dtype=torch.uint8, device='cuda')
-        typed_tensor_with_backup = torch.randn((10, 20, 30), dtype=torch.float32, device='cuda')
-        typed_tensor_with_backup_expected = typed_tensor_with_backup.clone()
+    with torch_memory_saver.region(enable_disk_backup=True):
+        big = torch.randn((numel,), dtype=torch.float32, device='cuda')
+        small = torch.full((7,), 10, dtype=torch.uint8, device='cuda')
+    big_oracle = big.detach().to('cpu').clone()
+    small_oracle = small.detach().to('cpu').clone()
 
     print("Allocate tensor_without_backup")
     with torch_memory_saver.region(enable_disk_backup=False):
-        tensor_without_backup = torch.full((20_000_000,), 20, dtype=torch.uint8, device='cuda')
+        no_backup = torch.full((20_000_000,), 20, dtype=torch.uint8, device='cuda')
 
-    assert tensor_with_backup[:3].tolist() == [10, 10, 10]
-    assert tensor_without_backup[:3].tolist() == [20, 20, 20]
+    assert torch.equal(big.cpu(), big_oracle)
+    assert no_backup[:3].tolist() == [20, 20, 20]
 
-    # Multiple pause/resume cycles: bytes must be restored bit-identically and
-    # the on-disk footprint must stay constant (files are overwritten in place).
-    disk_bytes = set()
+    disk_sizes = set()
     for _ in range(3):
         torch_memory_saver.pause()
-        disk_bytes.add(sum(os.path.getsize(os.path.join(disk_dir, f)) for f in os.listdir(disk_dir)))
 
-        # occupy the freed GPU space to prove it was actually reclaimed
-        tensor_unrelated = torch.full((20_000_000,), 30, dtype=torch.uint8, device='cuda')
-        del tensor_unrelated
+        files = os.listdir(disk_dir)
+        total = sum(os.path.getsize(os.path.join(disk_dir, f)) for f in files)
+        assert len(files) >= 2, f"expected a backup file per disk-backed alloc, got {files}"
+        assert total >= big.numel() * 4, f"backup smaller than the paused tensor: {total}"
+        disk_sizes.add(total)
+
+        occupy = torch.full((20_000_000,), 30, dtype=torch.uint8, device='cuda')
+        del occupy
         torch.cuda.empty_cache()
 
         torch_memory_saver.resume()
 
-        assert tensor_with_backup[:3].tolist() == [10, 10, 10]
-        assert tensor_without_backup[:3].tolist() != [20, 20, 20]
-        assert torch.equal(typed_tensor_with_backup, typed_tensor_with_backup_expected)
+        assert torch.equal(big.cpu(), big_oracle)
+        assert torch.equal(small.cpu(), small_oracle)
+        assert no_backup[:3].tolist() != [20, 20, 20]
 
-    assert len(disk_bytes) == 1, f"disk usage grew across cycles: {sorted(disk_bytes)}"
-    print(f"OK: bit-identical across cycles, disk constant at {next(iter(disk_bytes))} bytes")
+    assert len(disk_sizes) == 1, f"disk usage grew across cycles: {sorted(disk_sizes)}"
+    print(f"OK: {big.numel()} fp32 elems restored bit-identically across 3 cycles, "
+          f"disk constant at {next(iter(disk_sizes))} bytes")
 
 
 if __name__ == '__main__':

--- a/test/examples/disk_backup.py
+++ b/test/examples/disk_backup.py
@@ -1,0 +1,55 @@
+import logging
+import os
+import sys
+import tempfile
+
+import torch
+
+from torch_memory_saver import torch_memory_saver
+
+
+def run(hook_mode: str):
+    torch_memory_saver.hook_mode = hook_mode
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+
+    disk_dir = tempfile.mkdtemp(prefix="tms_disk_backup_")
+    print(f"disk_backup_dir={disk_dir}")
+
+    print("Allocate tensor_with_disk_backup")
+    with torch_memory_saver.region(enable_disk_backup=True, disk_backup_dir=disk_dir):
+        # Larger than the default staging chunk to exercise multi-chunk streaming.
+        tensor_with_backup = torch.full((20_000_000,), 10, dtype=torch.uint8, device='cuda')
+        typed_tensor_with_backup = torch.randn((10, 20, 30), dtype=torch.float32, device='cuda')
+        typed_tensor_with_backup_expected = typed_tensor_with_backup.clone()
+
+    print("Allocate tensor_without_backup")
+    with torch_memory_saver.region(enable_disk_backup=False):
+        tensor_without_backup = torch.full((20_000_000,), 20, dtype=torch.uint8, device='cuda')
+
+    assert tensor_with_backup[:3].tolist() == [10, 10, 10]
+    assert tensor_without_backup[:3].tolist() == [20, 20, 20]
+
+    # Multiple pause/resume cycles: bytes must be restored bit-identically and
+    # the on-disk footprint must stay constant (files are overwritten in place).
+    disk_bytes = set()
+    for _ in range(3):
+        torch_memory_saver.pause()
+        disk_bytes.add(sum(os.path.getsize(os.path.join(disk_dir, f)) for f in os.listdir(disk_dir)))
+
+        # occupy the freed GPU space to prove it was actually reclaimed
+        tensor_unrelated = torch.full((20_000_000,), 30, dtype=torch.uint8, device='cuda')
+        del tensor_unrelated
+        torch.cuda.empty_cache()
+
+        torch_memory_saver.resume()
+
+        assert tensor_with_backup[:3].tolist() == [10, 10, 10]
+        assert tensor_without_backup[:3].tolist() != [20, 20, 20]
+        assert torch.equal(typed_tensor_with_backup, typed_tensor_with_backup_expected)
+
+    assert len(disk_bytes) == 1, f"disk usage grew across cycles: {sorted(disk_bytes)}"
+    print(f"OK: bit-identical across cycles, disk constant at {next(iter(disk_bytes))} bytes")
+
+
+if __name__ == '__main__':
+    run(hook_mode=sys.argv[1])

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -6,7 +6,7 @@ import traceback
 import torch_memory_saver
 from torch_memory_saver.utils import change_env
 
-from examples import simple, cuda_graph, cpu_backup, rl_example, multi_device, multi_device_torch_mode, training_engine, nested_region
+from examples import simple, cuda_graph, cpu_backup, disk_backup, rl_example, multi_device, multi_device_torch_mode, training_engine, nested_region
 
 _HOOK_MODES = ["preload", "torch"]
 
@@ -24,6 +24,11 @@ def test_cuda_graph(hook_mode):
 @pytest.mark.parametrize("hook_mode", _HOOK_MODES)
 def test_cpu_backup(hook_mode):
     _test_core(cpu_backup.run, hook_mode=hook_mode)
+
+
+@pytest.mark.parametrize("hook_mode", _HOOK_MODES)
+def test_disk_backup(hook_mode):
+    _test_core(disk_backup.run, hook_mode=hook_mode)
 
 
 @pytest.mark.parametrize("hook_mode", _HOOK_MODES)

--- a/torch_memory_saver/binary_wrapper.py
+++ b/torch_memory_saver/binary_wrapper.py
@@ -14,10 +14,11 @@ class BinaryWrapper:
 
         _setup_function_signatures(self.cdll)
 
-    def set_config(self, *, tag: str, interesting_region: bool, enable_cpu_backup: bool):
+    def set_config(self, *, tag: str, interesting_region: bool, enable_cpu_backup: bool, enable_disk_backup: bool = False):
         self.cdll.tms_set_current_tag(tag.encode("utf-8"))
         self.cdll.tms_set_interesting_region(interesting_region)
         self.cdll.tms_set_enable_cpu_backup(enable_cpu_backup)
+        self.cdll.tms_set_enable_disk_backup(enable_disk_backup)
 
 
 def _setup_function_signatures(cdll):
@@ -28,6 +29,9 @@ def _setup_function_signatures(cdll):
     cdll.tms_get_interesting_region.restype = ctypes.c_bool
     cdll.tms_set_enable_cpu_backup.argtypes = [ctypes.c_bool]
     cdll.tms_get_enable_cpu_backup.restype = ctypes.c_bool
+    cdll.tms_set_enable_disk_backup.argtypes = [ctypes.c_bool]
+    cdll.tms_get_enable_disk_backup.restype = ctypes.c_bool
+    cdll.tms_set_disk_backup_dir.argtypes = [ctypes.c_char_p]
     cdll.tms_pause.argtypes = [ctypes.c_char_p]
     cdll.tms_resume.argtypes = [ctypes.c_char_p]
     cdll.set_memory_margin_bytes.argtypes = [ctypes.c_uint64]

--- a/torch_memory_saver/entrypoint.py
+++ b/torch_memory_saver/entrypoint.py
@@ -23,10 +23,22 @@ class TorchMemorySaver:
         self._impl: Optional[_TorchMemorySaverImpl] = None
 
     @contextmanager
-    def region(self, tag: str = _TAG_DEFAULT, enable_cpu_backup: bool = False):
-        """Context manager for memory saving with optional tag"""
+    def region(self, tag: str = _TAG_DEFAULT, enable_cpu_backup: bool = False,
+               enable_disk_backup: bool = False, disk_backup_dir: Optional[str] = None):
+        """Context manager for memory saving with optional tag.
+
+        When enable_disk_backup=True, paused memory is spilled to node-local
+        disk (disk_backup_dir) instead of a pinned CPU buffer, streamed in fixed
+        chunks so host RAM stays bounded. Mutually exclusive with
+        enable_cpu_backup. Use for the case where even CPU offload does not fit.
+        """
         self._ensure_initialized()
-        with self._impl.region(tag=tag, enable_cpu_backup=enable_cpu_backup):
+        assert not (enable_cpu_backup and enable_disk_backup), \
+            "enable_cpu_backup and enable_disk_backup are mutually exclusive"
+        if disk_backup_dir is not None:
+            self.set_disk_backup_dir(disk_backup_dir)
+        with self._impl.region(tag=tag, enable_cpu_backup=enable_cpu_backup,
+                               enable_disk_backup=enable_disk_backup):
             yield
 
     @contextmanager
@@ -87,6 +99,12 @@ class TorchMemorySaver:
         self._ensure_initialized()
         return self._impl.get_cpu_backup(x, zero_copy=zero_copy)
 
+    def set_disk_backup_dir(self, path: str):
+        """Set the node-local directory for disk backup files (created if needed)."""
+        self._ensure_initialized()
+        os.makedirs(path, exist_ok=True)
+        self._impl._binary_wrapper.cdll.tms_set_disk_backup_dir(path.encode("utf-8"))
+
     def _ensure_initialized(self):
         if self._impl is not None:
             return
@@ -109,12 +127,13 @@ class _TorchMemorySaverImpl:
             atexit.register(self._mem_pools.clear)
 
     @contextmanager
-    def region(self, tag: str, enable_cpu_backup: bool):
+    def region(self, tag: str, enable_cpu_backup: bool, enable_disk_backup: bool = False):
         # For hook_mode=preload, we need this b/c https://github.com/fzyzcjy/torch_memory_saver/pull/20#issuecomment-3047099047
         # (For hook_mode=torch we may not need it, but currently our primary usage is hook_mode=preload, thus we do this for simplicity)
-        mem_pool = self._mem_pools[(tag, enable_cpu_backup)]
+        mem_pool = self._mem_pools[(tag, enable_cpu_backup, enable_disk_backup)]
         with torch.cuda.use_mem_pool(mem_pool):
-            with self._with_region_config(tag=tag, enable_cpu_backup=enable_cpu_backup):
+            with self._with_region_config(tag=tag, enable_cpu_backup=enable_cpu_backup,
+                                          enable_disk_backup=enable_disk_backup):
                 yield
 
     @contextmanager
@@ -125,23 +144,28 @@ class _TorchMemorySaverImpl:
                 yield
 
     @contextmanager
-    def _with_region_config(self, tag: str, enable_cpu_backup: bool):
+    def _with_region_config(self, tag: str, enable_cpu_backup: bool, enable_disk_backup: bool = False):
         cdll = self._binary_wrapper.cdll
         orig_tag = cdll.tms_get_current_tag().decode("utf-8")
         orig_interesting_region = cdll.tms_get_interesting_region()
         orig_enable_cpu_backup = cdll.tms_get_enable_cpu_backup()
+        orig_enable_disk_backup = cdll.tms_get_enable_disk_backup()
 
-        self._binary_wrapper.set_config(tag=tag, interesting_region=True, enable_cpu_backup=enable_cpu_backup)
+        self._binary_wrapper.set_config(tag=tag, interesting_region=True,
+                                        enable_cpu_backup=enable_cpu_backup,
+                                        enable_disk_backup=enable_disk_backup)
         try:
             yield
         finally:
             assert cdll.tms_get_interesting_region()
             assert cdll.tms_get_enable_cpu_backup() == enable_cpu_backup
+            assert cdll.tms_get_enable_disk_backup() == enable_disk_backup
             assert cdll.tms_get_current_tag().decode("utf-8") == tag
             self._binary_wrapper.set_config(
                 tag=orig_tag,
                 interesting_region=orig_interesting_region,
                 enable_cpu_backup=orig_enable_cpu_backup,
+                enable_disk_backup=orig_enable_disk_backup,
             )
 
     @contextmanager

--- a/torch_memory_saver/entrypoint.py
+++ b/torch_memory_saver/entrypoint.py
@@ -24,19 +24,17 @@ class TorchMemorySaver:
 
     @contextmanager
     def region(self, tag: str = _TAG_DEFAULT, enable_cpu_backup: bool = False,
-               enable_disk_backup: bool = False, disk_backup_dir: Optional[str] = None):
+               enable_disk_backup: bool = False):
         """Context manager for memory saving with optional tag.
 
-        When enable_disk_backup=True, paused memory is spilled to node-local
-        disk (disk_backup_dir) instead of a pinned CPU buffer, streamed in fixed
-        chunks so host RAM stays bounded. Mutually exclusive with
-        enable_cpu_backup. Use for the case where even CPU offload does not fit.
+        enable_disk_backup spills paused memory to files instead of a pinned CPU
+        buffer; mutually exclusive with enable_cpu_backup. The target directory is
+        process-global (TMS_DISK_BACKUP_DIR or set_disk_backup_dir()), not
+        region-scoped, and must be a real disk mount (not tmpfs).
         """
         self._ensure_initialized()
         assert not (enable_cpu_backup and enable_disk_backup), \
             "enable_cpu_backup and enable_disk_backup are mutually exclusive"
-        if disk_backup_dir is not None:
-            self.set_disk_backup_dir(disk_backup_dir)
         with self._impl.region(tag=tag, enable_cpu_backup=enable_cpu_backup,
                                enable_disk_backup=enable_disk_backup):
             yield
@@ -100,7 +98,7 @@ class TorchMemorySaver:
         return self._impl.get_cpu_backup(x, zero_copy=zero_copy)
 
     def set_disk_backup_dir(self, path: str):
-        """Set the node-local directory for disk backup files (created if needed)."""
+        """Set the directory for disk backup files (created if needed)."""
         self._ensure_initialized()
         os.makedirs(path, exist_ok=True)
         self._impl._binary_wrapper.cdll.tms_set_disk_backup_dir(path.encode("utf-8"))
@@ -127,13 +125,10 @@ class _TorchMemorySaverImpl:
             atexit.register(self._mem_pools.clear)
 
     @contextmanager
-    def region(self, tag: str, enable_cpu_backup: bool, enable_disk_backup: bool = False):
-        # For hook_mode=preload, we need this b/c https://github.com/fzyzcjy/torch_memory_saver/pull/20#issuecomment-3047099047
-        # (For hook_mode=torch we may not need it, but currently our primary usage is hook_mode=preload, thus we do this for simplicity)
-        #
-        # A MemPool is bound to the current device at creation; key by device so a
-        # process using several devices (e.g. multiple TP ranks) doesn't reuse one
-        # device's pool for allocations on another (which bypasses the allocator).
+    def region(self, tag: str, enable_cpu_backup: bool, enable_disk_backup: bool):
+        # See https://github.com/fzyzcjy/torch_memory_saver/pull/20#issuecomment-3047099047
+        # Key by device too: a MemPool is bound to its creation device, so a
+        # multi-device process must not reuse one device's pool on another.
         key = (tag, enable_cpu_backup, enable_disk_backup, torch.cuda.current_device())
         mem_pool = self._mem_pools[key]
         with torch.cuda.use_mem_pool(mem_pool):

--- a/torch_memory_saver/utils.py
+++ b/torch_memory_saver/utils.py
@@ -46,8 +46,8 @@ def _detect_cuda_major() -> int:
         try:
             ctypes.CDLL(f"libcudart.so.{major}")
             return major
-        except OSError:
-            continue
+        except OSError as e:
+            logger.warning("probe for libcudart.so.%s failed: %s", major, e)
 
     raise RuntimeError(
         f"torch_memory_saver: could not detect CUDA runtime. Tried torch.version.cuda "


### PR DESCRIPTION
An `enable_disk_backup` mode alongside `enable_cpu_backup`: paused allocations are spilled to node-local files instead of a pinned CPU buffer.

## Why
`enable_cpu_backup` holds a full pinned host copy of every paused allocation. For large training actors (e.g. RL colocate) that can exceed host RAM. Disk backup streams **GPU → fixed pinned staging → file (`pwrite`)** and back on resume, so the pinned host buffer stays bounded to one staging chunk regardless of the total offloaded size — for the case where even CPU offload does not fit.

## Design
All the disk machinery lives in a standalone `DiskBackend` class (`csrc/disk_backend.{h,cpp}`), not mixed into `TorchMemorySaver`. Each allocation carries a small `DiskBackupSlot` (just the file path); `pause()`/`resume()` delegate to `DiskBackend::offload`/`onload`.

- **Atomic, unique files.** Files are created with `mkostemp` (`O_EXCL` + `O_CLOEXEC`), not a predictable `getpid()+counter` path — two containers sharing a PID namespace and a node-local mount could otherwise open the same inode and corrupt each other.
- **Bounded fds.** The fd is opened per transfer and closed after. PyTorch's MemPool caches allocator blocks, so a persistent per-block fd would grow with fragmentation and eventually hit `RLIMIT_NOFILE`; a transient fd keeps it flat.
- **Bounded disk.** The file is `posix_fallocate`d once (with an `ftruncate` fallback for mounts that don't support it) and overwritten in place every pause, so disk usage never grows across pause/resume cycles. Files are unlinked on free.
- **Cache control.** After each transfer, `fsync` + `posix_fadvise(POSIX_FADV_DONTNEED)` drops the file's page cache so cached bytes don't accumulate. A tmpfs/ramfs target is warned about — there the file itself lives in RAM.
- **Native mutual exclusion.** cpu/disk exclusion is enforced at the native `malloc` boundary, not only via a Python `assert` (which `-O` strips and direct C-API / env-var use bypasses).

## API
- `region(enable_disk_backup=True)`; the target directory is **process-global** (`TMS_DISK_BACKUP_DIR` or `set_disk_backup_dir()`), not region-scoped.
- C: `tms_{set,get}_enable_disk_backup`, `tms_set_disk_backup_dir`
- env: `TMS_INIT_ENABLE_DISK_BACKUP`, `TMS_DISK_BACKUP_DIR`, `TMS_DISK_BACKUP_CHUNK_MB` (default 256)

## Scope / notes
- Host-RAM bound is over the **pinned staging buffer + dropped page cache**; it is not a bound to zero on a RAM-backed mount. Point the dir at real disk.
- `get_cpu_backup_pointer` returns null for disk-backed allocations (no CPU-resident copy).
- ROCm 6.x legacy chunked path does not support disk backup and now hard-fails there rather than silently taking the wrong branch.
- GDS/cuFile is intentionally omitted in v1 (nvidia-fs absent in our target envs); the pinned-staging path gives the same bounded-buffer guarantee with no extra deps and can gain a cuFile fast-path later behind an import guard.

## Testing
**Unit / examples** — full suite green on 8×H200 (CUDA 13):
```
$ python -m pytest test/test_examples.py -q
...............
15 passed in 104.75s
```
`test/examples/disk_backup.py` forces a 1 MiB chunk so the tensors span ~13 chunks with a non-even tail, and compares the restored tensors byte-for-byte against an independent CPU oracle across 3 pause/resume cycles while asserting the on-disk footprint stays constant.

**End-to-end** — real miles RL run, Qwen3.5-35B-A3B, 8×H200, colocate, EP=8, `--offload-train-target=disk`:
- Ray job **SUCCEEDED**; all 3 rollouts × 2 train steps `outcome=NORMAL`.
- offload↔resume cycled cleanly every step: per-GPU used memory dropped to ~8–17 GB on offload and returned to ~64–108 GB on resume, 8 ranks consistent, tensors restored correctly (per-step logprob abs-diff stable).
- Backup files created as `tms_XXXXXX` (mkostemp); no `Too many open files`, no OOM, no mutual-exclusion trips across the whole run.
