### PR TITLE
Key MemPool by device so multi-device processes don't share a pool

### DIFF
--- a/test/examples/multi_device_torch_mode.py
+++ b/test/examples/multi_device_torch_mode.py
@@ -1,0 +1,71 @@
+"""Multi-device pause/resume in hook_mode="torch".
+
+A torch MemPool binds to the device that is current when it is created, and
+use_mem_pool only redirects allocations on that device. So each pauseable
+allocation must be made with its target device current (the realistic pattern:
+one process pins one device per TP rank).
+
+This protects the fix that keys _mem_pools by device: without it, the pool
+created for device 0 is reused for device 1, the device-1 allocation bypasses
+the custom allocator, and pause() fails to free it.
+
+Unlike multi_device.py (which allocates on a non-current device inside one
+region -- only the global-malloc preload hook can capture that), this pins each
+device at alloc time and therefore works in hook_mode="torch".
+
+Run directly:
+  python test/examples/multi_device_torch_mode.py torch
+"""
+
+import logging
+import sys
+
+import torch
+
+from torch_memory_saver import torch_memory_saver
+from torch_memory_saver.testing_utils import get_and_print_gpu_memory
+
+_ALLOC = 100_000_000  # ~100 MB uint8
+_FREED = 80_000_000   # expected drop/restore, with slack
+
+
+def run(hook_mode: str):
+    torch_memory_saver.hook_mode = hook_mode
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+
+    if torch.cuda.device_count() < 2:
+        print(f"skip: need >=2 CUDA devices, have {torch.cuda.device_count()}")
+        return
+
+    def used(d):
+        torch.cuda.synchronize(d)
+        return get_and_print_gpu_memory(f"dev{d}", gpu_id=d)
+
+    # Pin each device current at alloc time so its MemPool binds to it.
+    torch.cuda.set_device(0)
+    with torch_memory_saver.region(tag="t"):
+        a = torch.full((_ALLOC,), 1, dtype=torch.uint8, device="cuda:0")
+    torch.cuda.set_device(1)
+    with torch_memory_saver.region(tag="t"):
+        b = torch.full((_ALLOC,), 1, dtype=torch.uint8, device="cuda:1")
+    assert a.device == torch.device("cuda:0"), a.device
+    assert b.device == torch.device("cuda:1"), b.device
+    alloc0, alloc1 = used(0), used(1)
+
+    torch_memory_saver.pause("t")
+    pause0, pause1 = used(0), used(1)
+
+    torch_memory_saver.resume("t")
+    resume0, resume1 = used(0), used(1)
+
+    # Both devices must free on pause and re-commit on resume. The device-1
+    # assertions are what fail if the pool is not keyed by device.
+    assert (alloc0 - pause0) >= _FREED, "device 0 not freed on pause"
+    assert (alloc1 - pause1) >= _FREED, "device 1 not freed on pause"
+    assert (resume0 - pause0) >= _FREED, "device 0 not re-committed on resume"
+    assert (resume1 - pause1) >= _FREED, "device 1 not re-committed on resume"
+    print("multi_device_torch_mode OK")
+
+
+if __name__ == "__main__":
+    run(hook_mode=sys.argv[1] if len(sys.argv) > 1 else "torch")

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -6,7 +6,7 @@ import traceback
 import torch_memory_saver
 from torch_memory_saver.utils import change_env
 
-from examples import simple, cuda_graph, cpu_backup, rl_example, multi_device, training_engine, nested_region
+from examples import simple, cuda_graph, cpu_backup, rl_example, multi_device, multi_device_torch_mode, training_engine, nested_region
 
 _HOOK_MODES = ["preload", "torch"]
 
@@ -29,6 +29,12 @@ def test_cpu_backup(hook_mode):
 @pytest.mark.parametrize("hook_mode", _HOOK_MODES)
 def test_multi_device(hook_mode):
     _test_core(multi_device.run, hook_mode=hook_mode)
+
+
+def test_multi_device_torch_mode():
+    # Torch-mode multi-device: pins each device at alloc time. Protects the
+    # per-device MemPool keying (skips at runtime if <2 devices are present).
+    _test_core(multi_device_torch_mode.run, hook_mode="torch")
 
 
 @pytest.mark.parametrize("hook_mode", _HOOK_MODES)

--- a/torch_memory_saver/entrypoint.py
+++ b/torch_memory_saver/entrypoint.py
@@ -112,7 +112,12 @@ class _TorchMemorySaverImpl:
     def region(self, tag: str, enable_cpu_backup: bool):
         # For hook_mode=preload, we need this b/c https://github.com/fzyzcjy/torch_memory_saver/pull/20#issuecomment-3047099047
         # (For hook_mode=torch we may not need it, but currently our primary usage is hook_mode=preload, thus we do this for simplicity)
-        mem_pool = self._mem_pools[(tag, enable_cpu_backup)]
+        #
+        # A MemPool is bound to the current device at creation; key by device so a
+        # process using several devices (e.g. multiple TP ranks) doesn't reuse one
+        # device's pool for allocations on another (which bypasses the allocator).
+        key = (tag, enable_cpu_backup, torch.cuda.current_device())
+        mem_pool = self._mem_pools[key]
         with torch.cuda.use_mem_pool(mem_pool):
             with self._with_region_config(tag=tag, enable_cpu_backup=enable_cpu_backup):
                 yield


### PR DESCRIPTION
A torch MemPool binds to the device that is current when it is created, and use_mem_pool only redirects allocations on that device. _mem_pools was keyed by (tag, enable_cpu_backup), so a process using several devices (e.g. multiple TP ranks) reused the first device's pool for allocations on another device -- those allocations bypass the custom allocator and are not paused/resumed.

Add the current device to the pool key so each device gets its own pool.

Add a torch-mode multi-device test (multi_device_torch_mode.py) that pins each device at alloc time and asserts both devices free on pause / re-commit on resume; it fails without this fix. Skips when <2 devices are available.