### PR TITLE
Fix ROCm 7.2: free VA in pause() so physical memory is actually released

### DIFF
--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -131,10 +131,14 @@ void TorchMemorySaver::pause(const std::string& tag) {
 
         CURESULT_CHECK(cuMemUnmap((CUdeviceptr) ptr, metadata.size));
         CURESULT_CHECK(cuMemRelease(metadata.allocHandle));
+#if defined(USE_ROCM)
         // On ROCm 7.2, cuMemUnmap + cuMemRelease do not return the physical pages to
         // the driver while the virtual address range stays reserved (they do on ROCm
-        // 7.0). Free the VA to actually release the memory, then immediately re-reserve
-        // the SAME address as a placeholder so the pointer stays valid for resume().
+        // 7.0 and on CUDA). Free the VA to actually release the memory, then immediately
+        // re-reserve the SAME address as a placeholder so the pointer stays valid for
+        // resume(). ROCm-only: CUDA already frees the physical on release, so it does
+        // not need this and must not be exposed to the (small) free->re-reserve window
+        // where another thread could grab the address.
         CURESULT_CHECK(cuMemAddressFree((CUdeviceptr) ptr, metadata.size));
         {
             CUdeviceptr reserved = 0;
@@ -147,6 +151,7 @@ void TorchMemorySaver::pause(const std::string& tag) {
                 exit(1);
             }
         }
+#endif
 
         metadata.state = AllocationState::PAUSED;
 

--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -131,6 +131,22 @@ void TorchMemorySaver::pause(const std::string& tag) {
 
         CURESULT_CHECK(cuMemUnmap((CUdeviceptr) ptr, metadata.size));
         CURESULT_CHECK(cuMemRelease(metadata.allocHandle));
+        // On ROCm 7.2, cuMemUnmap + cuMemRelease do not return the physical pages to
+        // the driver while the virtual address range stays reserved (they do on ROCm
+        // 7.0). Free the VA to actually release the memory, then immediately re-reserve
+        // the SAME address as a placeholder so the pointer stays valid for resume().
+        CURESULT_CHECK(cuMemAddressFree((CUdeviceptr) ptr, metadata.size));
+        {
+            CUdeviceptr reserved = 0;
+            CURESULT_CHECK(cuMemAddressReserve(&reserved, metadata.size, 0, (CUdeviceptr) ptr, 0));
+            if ((void*) reserved != ptr) {
+                std::cerr << "[torch_memory_saver.cpp] pause() could not re-reserve the same VA:"
+                          << " want=" << ptr << " got=" << (void*) reserved
+                          << " file=" << __FILE__ << " func=" << __func__ << " line=" << __LINE__
+                          << std::endl;
+                exit(1);
+            }
+        }
 
         metadata.state = AllocationState::PAUSED;
 


### PR DESCRIPTION
Fixes #83.

## Problem

On **ROCm 7.2**, `pause()` returns successfully but does **not** free the physical GPU memory — `torch.cuda.mem_get_info()` is unchanged. A later `resume()` then OOMs on `cuMemCreate` (`csrc/core.cpp func=resume`) once the paused allocation is large enough. The **same source build works on ROCm 7.0**, so it's a ROCm 7.2 behavior change in the VMM path: `cuMemUnmap` + `cuMemRelease` no longer return the physical pages while the virtual address range stays reserved.

## Fix

In `pause()` (non-`TMS_ROCM_LEGACY_CHUNKED` path), after `cuMemUnmap` + `cuMemRelease`, also `cuMemAddressFree` the range so the physical memory is actually returned, then **immediately re-reserve the same address** as a placeholder so the allocation pointer stays valid for `resume()`. `resume()` is unchanged (it maps a fresh handle into the already-reserved VA).

This is safe on ROCm 7.0 as well (the VA is simply freed and re-reserved in place), and CUDA behavior is unchanged for the common case since the re-reserved address is verified to match.

## Verification (ROCm 7.2, HIP 7.2.26015, MI30x, 256 GB)

Minimal repro (allocate 30 GB inside a `region`, pause, resume):

| stage | before fix | after fix |
|---|---|---|
| after alloc | free 225.2 GB | free 225.2 GB |
| after `pause()` | free 225.2 GB (freed 0) ❌ | free **255.2 GB** (freed ~30) ✅ |
| after `resume()` | — | free 225.2 GB (re-mapped, same VA) ✅ |

Also validated end-to-end in a colocated verl + SGLang RL run at `gpu_memory_utilization=0.8` on ROCm 7.2: SGLang's KV-cache pool is now actually released during training (~175 GB freed at `release_memory_occupation`), `resume_memory_occupation` no longer OOMs, and training completes multiple steps — a configuration that previously always OOM'd. No regression observed on ROCm 7.0.