### PR TITLE
Retain pinned CPU backups across resume cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ to expose the retained backup after resume.
 
 The policy is consulted on resume. Setting it to `False` does not eagerly free
 backups for active allocations; they are released by a later non-retaining
-resume, when the allocation is freed, or during process cleanup.
+resume, when the allocation is freed, or when the process exits.
 
 ### Hook Modes
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ torch_memory_saver.resume()
 assert tensor1[0] == 42, "content is kept unchanged"
 ```
 
+On CUDA, pinned CPU backups can be retained across resume cycles to avoid
+reallocating them before every pause:
+
+```python
+torch_memory_saver.retain_cpu_backup = True
+```
+
+Set `TMS_RETAIN_CPU_BACKUP=1` before process startup to enable the same policy,
+including for preload mode. Retention is CUDA-only and can consume pinned RAM
+equal to the backed-up allocations. While enabled, `get_cpu_backup` continues
+to expose the retained backup after resume.
+
+The policy is consulted on resume. Setting it to `False` does not eagerly free
+backups for active allocations; they are released by a later non-retaining
+resume, when the allocation is freed, or during process cleanup.
+
 ### Hook Modes
 
 There are two hook modes:

--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -283,18 +283,6 @@ cudaError_t TorchMemorySaver::resume(const std::string& tag) {
 #endif
 }
 
-void TorchMemorySaver::release_cpu_backups() {
-#ifdef USE_CUDA
-    const std::lock_guard<std::mutex> lock(allocator_metadata_mutex_);
-    for (auto& [ptr, metadata] : allocation_metadata_) {
-        if (metadata.cpu_backup != nullptr) {
-            CUDA_ERROR_CHECK(cudaFreeHost(metadata.cpu_backup));
-            metadata.cpu_backup = nullptr;
-        }
-    }
-#endif
-}
-
 uint8_t* TorchMemorySaver::get_cpu_backup_pointer(const uint8_t* query_gpu_ptr, uint64_t query_size) {
     const std::lock_guard <std::mutex> lock(allocator_metadata_mutex_);
 

--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -5,9 +5,7 @@
 
 TorchMemorySaver::TorchMemorySaver() {
 #ifdef USE_CUDA
-    const char* retain_cpu_backup = std::getenv("TMS_RETAIN_CPU_BACKUP");
-    retain_cpu_backup_.store(
-        retain_cpu_backup != nullptr && std::string(retain_cpu_backup) == "1");
+    retain_cpu_backup_.store(get_bool_env_var("TMS_RETAIN_CPU_BACKUP"));
 #endif
 }
 

--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -236,7 +236,9 @@ uint8_t* TorchMemorySaver::get_cpu_backup_pointer(const uint8_t* query_gpu_ptr, 
         if ((ptr <= query_gpu_ptr) && (query_gpu_ptr + query_size <= ptr + total_size)) {
             const size_t offset = query_gpu_ptr - ptr;
             if (metadata.state == AllocationState::ACTIVE) {
-                return nullptr;
+                return metadata.cpu_backup == nullptr
+                    ? nullptr
+                    : (uint8_t*) metadata.cpu_backup + offset;
             } else {
                 SIMPLE_CHECK(nullptr != metadata.cpu_backup,
                     "get_cpu_backup_pointer: found paused allocation but cpu_backup does not exist, do you forget to enable cpu backup");

--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -3,7 +3,13 @@
 #include "macro.h"
 #include "api_forwarder.h"
 
-TorchMemorySaver::TorchMemorySaver() {}
+TorchMemorySaver::TorchMemorySaver() {
+#ifdef USE_CUDA
+    const char* retain_cpu_backup = std::getenv("TMS_RETAIN_CPU_BACKUP");
+    retain_cpu_backup_.store(
+        retain_cpu_backup != nullptr && std::string(retain_cpu_backup) == "1");
+#endif
+}
 
 TorchMemorySaver &TorchMemorySaver::instance() {
     static TorchMemorySaver instance;
@@ -151,6 +157,7 @@ void TorchMemorySaver::resume(const std::string& tag) {
 
 #else
     const std::lock_guard <std::mutex> lock(allocator_metadata_mutex_);
+    const bool retain_cpu_backup = retain_cpu_backup_.load();
 
     for (auto it = allocation_metadata_.begin(); it != allocation_metadata_.end(); ++it) {
         void *ptr = it->first;
@@ -180,10 +187,10 @@ void TorchMemorySaver::resume(const std::string& tag) {
             // TODO may use cudaMemcpyAsync if needed
             CUDA_ERROR_CHECK(cudaMemcpy(ptr, metadata.cpu_backup, metadata.size, cudaMemcpyHostToDevice));
 
-            // TODO may provide a flag to choose whether to free immediately
-            // (users may want to lazily free to reduce re-alloc time)
-            CUDA_ERROR_CHECK(cudaFreeHost(metadata.cpu_backup));
-            metadata.cpu_backup = nullptr;
+            if (!retain_cpu_backup) {
+                CUDA_ERROR_CHECK(cudaFreeHost(metadata.cpu_backup));
+                metadata.cpu_backup = nullptr;
+            }
         }
 
 #ifdef TMS_DEBUG_LOG
@@ -197,6 +204,18 @@ void TorchMemorySaver::resume(const std::string& tag) {
 
         metadata.state = AllocationState::ACTIVE;
         metadata.allocHandle = newAllocHandle;
+    }
+#endif
+}
+
+void TorchMemorySaver::release_cpu_backups() {
+#ifdef USE_CUDA
+    const std::lock_guard<std::mutex> lock(allocator_metadata_mutex_);
+    for (auto& [ptr, metadata] : allocation_metadata_) {
+        if (metadata.cpu_backup != nullptr) {
+            CUDA_ERROR_CHECK(cudaFreeHost(metadata.cpu_backup));
+            metadata.cpu_backup = nullptr;
+        }
     }
 #endif
 }

--- a/csrc/core.h
+++ b/csrc/core.h
@@ -85,7 +85,6 @@ public:
     bool get_retain_cpu_backup() const {
         return retain_cpu_backup_.load();
     }
-    void release_cpu_backups();
     uint8_t* get_cpu_backup_pointer(const uint8_t* query_gpu_ptr, uint64_t query_size);
     void set_disk_backup_dir(const std::string& dir) {
         const std::lock_guard<std::mutex> lock(allocator_metadata_mutex_);

--- a/csrc/core.h
+++ b/csrc/core.h
@@ -51,6 +51,13 @@ public:
     void set_memory_margin_bytes(uint64_t value) {
         memory_margin_bytes_.store(value);
     }
+    void set_retain_cpu_backup(bool value) {
+        retain_cpu_backup_.store(value);
+    }
+    bool get_retain_cpu_backup() const {
+        return retain_cpu_backup_.load();
+    }
+    void release_cpu_backups();
     uint8_t* get_cpu_backup_pointer(const uint8_t* query_gpu_ptr, uint64_t query_size);
 
 private:
@@ -62,4 +69,5 @@ private:
     std::mutex allocator_metadata_mutex_;
     std::unordered_map<void*, AllocationMetadata> allocation_metadata_;
     std::atomic<uint64_t> memory_margin_bytes_ = 0;
+    std::atomic<bool> retain_cpu_backup_ = false;
 };

--- a/csrc/entrypoint.cpp
+++ b/csrc/entrypoint.cpp
@@ -114,6 +114,26 @@ void set_memory_margin_bytes(uint64_t value) {
     TorchMemorySaver::instance().set_memory_margin_bytes(value);
 }
 
+void tms_set_retain_cpu_backup(bool retain_cpu_backup) {
+#ifdef USE_ROCM
+    SIMPLE_CHECK(!retain_cpu_backup, "retained CPU backup policy is CUDA-only");
+#else
+    TorchMemorySaver::instance().set_retain_cpu_backup(retain_cpu_backup);
+#endif
+}
+
+bool tms_get_retain_cpu_backup() {
+#ifdef USE_ROCM
+    return false;
+#else
+    return TorchMemorySaver::instance().get_retain_cpu_backup();
+#endif
+}
+
+void tms_release_cpu_backups() {
+    TorchMemorySaver::instance().release_cpu_backups();
+}
+
 void tms_pause(const char* tag) {
     std::string tag_str = (tag != nullptr) ? std::string(tag) : "";
     TorchMemorySaver::instance().pause(tag_str);

--- a/csrc/entrypoint.cpp
+++ b/csrc/entrypoint.cpp
@@ -159,10 +159,6 @@ bool tms_get_retain_cpu_backup() {
 #endif
 }
 
-void tms_release_cpu_backups() {
-    TorchMemorySaver::instance().release_cpu_backups();
-}
-
 int tms_pause(const char* tag) {
     std::string tag_str = (tag != nullptr) ? std::string(tag) : "";
     return static_cast<int>(TorchMemorySaver::instance().pause(tag_str));

--- a/test/examples/cpu_backup.py
+++ b/test/examples/cpu_backup.py
@@ -72,6 +72,10 @@ def run(hook_mode: str):
             first_pointer = first_backup.data_ptr()
             assert other[0].item() == 80 + device
             torch_memory_saver.resume(tag=f"retained_{device}")
+            assert (
+                torch_memory_saver.get_cpu_backup(selected, zero_copy=True).data_ptr()
+                == first_pointer
+            )
 
             selected.fill_(50 + device)
             torch_memory_saver.pause(tag=f"retained_{device}")

--- a/test/examples/cpu_backup.py
+++ b/test/examples/cpu_backup.py
@@ -9,6 +9,7 @@ from torch_memory_saver import torch_memory_saver
 def run(hook_mode: str):
     torch_memory_saver.hook_mode = hook_mode
     logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+    assert torch_memory_saver.retain_cpu_backup is False
 
     print("Allocate tensor_with_backup")
     with torch_memory_saver.region(enable_cpu_backup=True):
@@ -37,6 +38,54 @@ def run(hook_mode: str):
     print(f"{tensor_with_backup[:3]=} {tensor_without_backup[:3]=}")
     assert tensor_with_backup[:3].tolist() == [10, 10, 10]
     assert tensor_without_backup[:3].tolist() != [20, 20, 20]
+
+    # Retention keeps the pinned allocation across resume. A later pause must
+    # refresh its contents rather than restoring the previous snapshot.
+    torch_memory_saver.retain_cpu_backup = True
+    tensor_with_backup.fill_(11)
+    torch_memory_saver.pause()
+    retained = torch_memory_saver.get_cpu_backup(tensor_with_backup)
+    assert retained[:3].tolist() == [11, 11, 11]
+    torch_memory_saver.resume()
+    assert tensor_with_backup[:3].tolist() == [11, 11, 11]
+
+    tensor_with_backup.fill_(12)
+    torch_memory_saver.pause()
+    retained = torch_memory_saver.get_cpu_backup(tensor_with_backup)
+    assert retained[:3].tolist() == [12, 12, 12]
+    torch_memory_saver.resume()
+    assert tensor_with_backup[:3].tolist() == [12, 12, 12]
+    torch_memory_saver.retain_cpu_backup = False
+
+    # Tags remain independent, and retained host storage is reused at the same
+    # address while its bytes are refreshed. Exercise every visible device.
+    for device in range(torch.cuda.device_count()):
+        with torch.cuda.device(device):
+            with torch_memory_saver.region(tag=f"retained_{device}", enable_cpu_backup=True):
+                selected = torch.full((1024,), 40 + device, dtype=torch.uint8, device=device)
+            with torch_memory_saver.region(tag=f"other_{device}", enable_cpu_backup=True):
+                other = torch.full((1024,), 80 + device, dtype=torch.uint8, device=device)
+
+            torch_memory_saver.retain_cpu_backup = True
+            torch_memory_saver.pause(tag=f"retained_{device}")
+            first_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+            first_pointer = first_backup.data_ptr()
+            assert other[0].item() == 80 + device
+            torch_memory_saver.resume(tag=f"retained_{device}")
+
+            selected.fill_(50 + device)
+            torch_memory_saver.pause(tag=f"retained_{device}")
+            second_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+            assert second_backup.data_ptr() == first_pointer
+            assert second_backup[0].item() == 50 + device
+            torch_memory_saver.resume(tag=f"retained_{device}")
+            assert selected[0].item() == 50 + device
+            torch_memory_saver.retain_cpu_backup = False
+
+
+def run_retain_from_env(hook_mode: str):
+    torch_memory_saver.hook_mode = hook_mode
+    assert torch_memory_saver.retain_cpu_backup is True
 
 
 if __name__ == '__main__':

--- a/test/examples/cpu_backup.py
+++ b/test/examples/cpu_backup.py
@@ -1,3 +1,5 @@
+import ctypes
+import gc
 import logging
 import sys
 
@@ -41,40 +43,141 @@ def run(hook_mode: str):
     print(f"{tensor_with_backup[:3]=} {tensor_without_backup[:3]=}")
     assert tensor_with_backup[:3].tolist() == [10, 10, 10]
     assert tensor_without_backup[:3].tolist() != [20, 20, 20]
+    assert torch_memory_saver.get_cpu_backup(tensor_with_backup) is None
 
     # Tags remain independent, and retained host storage is reused at the same
     # address while its bytes are refreshed. Exercise every visible device.
     for device in range(torch.cuda.device_count()):
         with torch.cuda.device(device):
-            with torch_memory_saver.region(tag=f"retained_{device}", enable_cpu_backup=True):
-                selected = torch.full((1024,), 40 + device, dtype=torch.uint8, device=device)
-            with torch_memory_saver.region(tag=f"other_{device}", enable_cpu_backup=True):
-                other = torch.full((1024,), 80 + device, dtype=torch.uint8, device=device)
+            selected_expected = _make_pattern(size=1024, offset=40 + device)
+            other_expected = _make_pattern(size=1024, offset=80 + device)
 
-            torch_memory_saver.retain_cpu_backup = True
+            with torch_memory_saver.region(tag=f"retained_{device}", enable_cpu_backup=True):
+                selected = selected_expected.to(device)
+            with torch_memory_saver.region(tag=f"other_{device}", enable_cpu_backup=True):
+                other = other_expected.to(device)
+
             torch_memory_saver.pause(tag=f"retained_{device}")
             first_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
             first_pointer = first_backup.data_ptr()
-            assert other[0].item() == 80 + device
-            torch_memory_saver.resume(tag=f"retained_{device}")
-            assert (
-                torch_memory_saver.get_cpu_backup(selected, zero_copy=True).data_ptr()
-                == first_pointer
-            )
+            assert torch.equal(first_backup, selected_expected)
+            assert torch.equal(other.cpu(), other_expected)
 
-            selected.fill_(50 + device)
+            torch_memory_saver.retain_cpu_backup = True
+            assert torch_memory_saver.retain_cpu_backup is True
+            del first_backup
+            torch_memory_saver.resume(tag=f"retained_{device}")
+            retained_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+            assert retained_backup.data_ptr() == first_pointer
+            assert torch.equal(retained_backup, selected_expected)
+            assert torch.equal(selected.cpu(), selected_expected)
+            del retained_backup
+
+            torch_memory_saver.retain_cpu_backup = False
+            assert torch_memory_saver.retain_cpu_backup is False
+            retained_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+            assert retained_backup.data_ptr() == first_pointer
+            assert torch.equal(retained_backup, selected_expected)
+            del retained_backup
+
+            selected_expected = _make_pattern(size=1024, offset=50 + device)
+            selected.copy_(selected_expected)
             torch_memory_saver.pause(tag=f"retained_{device}")
             second_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
             assert second_backup.data_ptr() == first_pointer
-            assert second_backup[0].item() == 50 + device
+            assert torch.equal(second_backup, selected_expected)
+
+            torch_memory_saver.retain_cpu_backup = True
+            del second_backup
             torch_memory_saver.resume(tag=f"retained_{device}")
-            assert selected[0].item() == 50 + device
+            retained_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+            assert retained_backup.data_ptr() == first_pointer
+            assert torch.equal(retained_backup, selected_expected)
+            assert torch.equal(selected.cpu(), selected_expected)
+            del retained_backup
+
+            selected_expected = _make_pattern(size=1024, offset=60 + device)
+            selected.copy_(selected_expected)
+            torch_memory_saver.pause(tag=f"retained_{device}")
+            third_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+            assert third_backup.data_ptr() == first_pointer
+            assert torch.equal(third_backup, selected_expected)
+
             torch_memory_saver.retain_cpu_backup = False
+            del third_backup
+            torch_memory_saver.resume(tag=f"retained_{device}")
+            assert torch.equal(selected.cpu(), selected_expected)
+            assert torch_memory_saver.get_cpu_backup(selected) is None
+
+            _assert_cpu_backup_released_on_allocation_free(device=device, paused=False)
+            _assert_cpu_backup_released_on_allocation_free(device=device, paused=True)
 
 
 def run_retain_from_env(hook_mode: str):
     torch_memory_saver.hook_mode = hook_mode
     assert torch_memory_saver.retain_cpu_backup is True
+
+
+def _assert_cpu_backup_released_on_allocation_free(device: int, paused: bool) -> None:
+    state = "paused" if paused else "active"
+    tag = f"retained_free_{state}_{device}"
+    expected = _make_pattern(size=4096, offset=100 + device + int(paused))
+
+    with torch_memory_saver.region(tag=tag, enable_cpu_backup=True):
+        tensor = expected.to(device)
+
+    torch_memory_saver.retain_cpu_backup = True
+    torch_memory_saver.pause(tag=tag)
+    backup = torch_memory_saver.get_cpu_backup(tensor, zero_copy=True)
+    backup_pointer = backup.data_ptr()
+    assert torch.equal(backup, expected)
+    assert _cuda_host_pointer_is_allocated(backup_pointer)
+
+    if not paused:
+        del backup
+        torch_memory_saver.resume(tag=tag)
+        backup = torch_memory_saver.get_cpu_backup(tensor, zero_copy=True)
+        assert backup.data_ptr() == backup_pointer
+        assert torch.equal(backup, expected)
+        assert torch.equal(tensor.cpu(), expected)
+
+    pool_key = (tag, True, False, device)
+    pool = torch_memory_saver._impl._mem_pools.pop(pool_key)
+    torch.cuda.synchronize(device)
+    del backup
+
+    with torch_memory_saver._impl._with_region_config(
+        tag=tag,
+        enable_cpu_backup=True,
+    ):
+        del tensor
+        del pool
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    torch.cuda.synchronize(device)
+    assert not _cuda_host_pointer_is_allocated(backup_pointer)
+    torch_memory_saver.retain_cpu_backup = False
+
+
+def _cuda_host_pointer_is_allocated(pointer: int) -> bool:
+    cdll = torch_memory_saver._impl._binary_wrapper.cdll
+    cuda_host_get_flags = cdll.cudaHostGetFlags
+    cuda_host_get_flags.argtypes = [ctypes.POINTER(ctypes.c_uint), ctypes.c_void_p]
+    cuda_host_get_flags.restype = ctypes.c_int
+    cuda_get_last_error = cdll.cudaGetLastError
+    cuda_get_last_error.argtypes = []
+    cuda_get_last_error.restype = ctypes.c_int
+
+    flags = ctypes.c_uint()
+    status = cuda_host_get_flags(ctypes.byref(flags), ctypes.c_void_p(pointer))
+    if status != 0:
+        cuda_get_last_error()
+    return status == 0
+
+
+def _make_pattern(size: int, offset: int) -> torch.Tensor:
+    return torch.arange(size, dtype=torch.int64).add(offset).remainder(251).to(torch.uint8)
 
 
 if __name__ == '__main__':

--- a/test/examples/cpu_backup.py
+++ b/test/examples/cpu_backup.py
@@ -39,24 +39,6 @@ def run(hook_mode: str):
     assert tensor_with_backup[:3].tolist() == [10, 10, 10]
     assert tensor_without_backup[:3].tolist() != [20, 20, 20]
 
-    # Retention keeps the pinned allocation across resume. A later pause must
-    # refresh its contents rather than restoring the previous snapshot.
-    torch_memory_saver.retain_cpu_backup = True
-    tensor_with_backup.fill_(11)
-    torch_memory_saver.pause()
-    retained = torch_memory_saver.get_cpu_backup(tensor_with_backup)
-    assert retained[:3].tolist() == [11, 11, 11]
-    torch_memory_saver.resume()
-    assert tensor_with_backup[:3].tolist() == [11, 11, 11]
-
-    tensor_with_backup.fill_(12)
-    torch_memory_saver.pause()
-    retained = torch_memory_saver.get_cpu_backup(tensor_with_backup)
-    assert retained[:3].tolist() == [12, 12, 12]
-    torch_memory_saver.resume()
-    assert tensor_with_backup[:3].tolist() == [12, 12, 12]
-    torch_memory_saver.retain_cpu_backup = False
-
     # Tags remain independent, and retained host storage is reused at the same
     # address while its bytes are refreshed. Exercise every visible device.
     for device in range(torch.cuda.device_count()):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -27,6 +27,12 @@ def test_cpu_backup(hook_mode):
 
 
 @pytest.mark.parametrize("hook_mode", _HOOK_MODES)
+def test_cpu_backup_retain_from_env(hook_mode):
+    with change_env("TMS_RETAIN_CPU_BACKUP", "1"):
+        _test_core(cpu_backup.run_retain_from_env, hook_mode=hook_mode)
+
+
+@pytest.mark.parametrize("hook_mode", _HOOK_MODES)
 def test_multi_device(hook_mode):
     _test_core(multi_device.run, hook_mode=hook_mode)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,10 +2,27 @@ import sys
 from types import SimpleNamespace
 
 from torch_memory_saver import utils
+from torch_memory_saver.entrypoint import _TorchMemorySaverImpl
 
 
 def _fake_torch(cuda=None, hip=None):
     return SimpleNamespace(version=SimpleNamespace(cuda=cuda, hip=hip))
+
+
+def test_cuda_exit_cleanup_order():
+    calls = []
+    impl = object.__new__(_TorchMemorySaverImpl)
+    impl._binary_wrapper = SimpleNamespace(
+        cdll=SimpleNamespace(
+            tms_set_interesting_region=lambda value: calls.append(("region", value)),
+            tms_release_cpu_backups=lambda: calls.append(("release",)),
+        )
+    )
+    impl._mem_pools = SimpleNamespace(clear=lambda: calls.append(("clear",)))
+
+    impl._cleanup_cuda_at_exit()
+
+    assert calls == [("region", True), ("clear",), ("release",)]
 
 
 def test_get_binary_path_from_package_uses_unsuffixed_rocm_binary(monkeypatch, tmp_path):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,28 +3,11 @@ import sys
 from types import SimpleNamespace
 
 from torch_memory_saver import utils
-from torch_memory_saver.entrypoint import _TorchMemorySaverImpl
 from torch_memory_saver.utils import change_env
 
 
 def _fake_torch(cuda=None, hip=None):
     return SimpleNamespace(version=SimpleNamespace(cuda=cuda, hip=hip))
-
-
-def test_cuda_exit_cleanup_order():
-    calls = []
-    impl = object.__new__(_TorchMemorySaverImpl)
-    impl._binary_wrapper = SimpleNamespace(
-        cdll=SimpleNamespace(
-            tms_set_interesting_region=lambda value: calls.append(("region", value)),
-            tms_release_cpu_backups=lambda: calls.append(("release",)),
-        )
-    )
-    impl._mem_pools = SimpleNamespace(clear=lambda: calls.append(("clear",)))
-
-    impl._cleanup_cuda_at_exit()
-
-    assert calls == [("region", True), ("clear",), ("release",)]
 
 
 def test_get_binary_path_from_package_uses_unsuffixed_rocm_binary(monkeypatch, tmp_path):

--- a/torch_memory_saver/binary_wrapper.py
+++ b/torch_memory_saver/binary_wrapper.py
@@ -31,5 +31,8 @@ def _setup_function_signatures(cdll):
     cdll.tms_pause.argtypes = [ctypes.c_char_p]
     cdll.tms_resume.argtypes = [ctypes.c_char_p]
     cdll.set_memory_margin_bytes.argtypes = [ctypes.c_uint64]
+    cdll.tms_set_retain_cpu_backup.argtypes = [ctypes.c_bool]
+    cdll.tms_get_retain_cpu_backup.restype = ctypes.c_bool
+    cdll.tms_release_cpu_backups.argtypes = []
     cdll.tms_get_cpu_backup_pointer.argtypes = [ctypes.POINTER(ctypes.c_uint8), ctypes.c_uint64]
     cdll.tms_get_cpu_backup_pointer.restype = ctypes.POINTER(ctypes.c_uint8)

--- a/torch_memory_saver/binary_wrapper.py
+++ b/torch_memory_saver/binary_wrapper.py
@@ -39,7 +39,6 @@ def _setup_function_signatures(cdll):
     cdll.set_memory_margin_bytes.argtypes = [ctypes.c_uint64]
     cdll.tms_set_retain_cpu_backup.argtypes = [ctypes.c_bool]
     cdll.tms_get_retain_cpu_backup.restype = ctypes.c_bool
-    cdll.tms_release_cpu_backups.argtypes = []
     cdll.tms_get_cpu_backup_pointer.argtypes = [ctypes.POINTER(ctypes.c_uint8), ctypes.c_uint64]
     cdll.tms_get_cpu_backup_pointer.restype = ctypes.POINTER(ctypes.c_uint8)
 

--- a/torch_memory_saver/entrypoint.py
+++ b/torch_memory_saver/entrypoint.py
@@ -159,15 +159,6 @@ class _TorchMemorySaverImpl:
             # HIP/SYCL runtime static dtors may run before MemPool's at exit
             # (destruction-order fiasco); free pools via atexit while runtime alive.
             atexit.register(self._mem_pools.clear)
-        else:
-            # Destroy pools while CUDA and the allocator configuration are
-            # alive, then release any backups not owned by a Python MemPool.
-            atexit.register(self._cleanup_cuda_at_exit)
-
-    def _cleanup_cuda_at_exit(self):
-        self._binary_wrapper.cdll.tms_set_interesting_region(True)
-        self._mem_pools.clear()
-        self._binary_wrapper.cdll.tms_release_cpu_backups()
 
     @contextmanager
     def region(self, tag: str, enable_cpu_backup: bool, enable_disk_backup: bool):

--- a/torch_memory_saver/entrypoint.py
+++ b/torch_memory_saver/entrypoint.py
@@ -83,6 +83,16 @@ class TorchMemorySaver:
         self._ensure_initialized()
         self._impl._binary_wrapper.cdll.set_memory_margin_bytes(value)
 
+    @property
+    def retain_cpu_backup(self) -> bool:
+        self._ensure_initialized()
+        return self._impl._binary_wrapper.cdll.tms_get_retain_cpu_backup()
+
+    @retain_cpu_backup.setter
+    def retain_cpu_backup(self, value: bool):
+        self._ensure_initialized()
+        self._impl._binary_wrapper.cdll.tms_set_retain_cpu_backup(value)
+
     def get_cpu_backup(self, x: torch.Tensor, zero_copy: bool = False):
         self._ensure_initialized()
         return self._impl.get_cpu_backup(x, zero_copy=zero_copy)
@@ -107,6 +117,15 @@ class _TorchMemorySaverImpl:
             # destruction order fiasco"). By clearing _mem_pools in an atexit handler, we ensure MemPool 
             # destruction (and thus HIP API calls) happens while the HIP/HSA runtime is still fully alive.
             atexit.register(self._mem_pools.clear)
+        else:
+            # Destroy pools while CUDA and the allocator configuration are
+            # alive, then release any backups not owned by a Python MemPool.
+            atexit.register(self._cleanup_cuda_at_exit)
+
+    def _cleanup_cuda_at_exit(self):
+        self._binary_wrapper.cdll.tms_set_interesting_region(True)
+        self._mem_pools.clear()
+        self._binary_wrapper.cdll.tms_release_cpu_backups()
 
     @contextmanager
     def region(self, tag: str, enable_cpu_backup: bool):


### PR DESCRIPTION
## Summary

Add an opt-in CUDA policy that retains pinned CPU backups across resume cycles:

- `torch_memory_saver.retain_cpu_backup = True`
- `TMS_RETAIN_CPU_BACKUP=1` at process startup

A later pause refreshes the retained storage in place. The existing backup query exposes the retained snapshot after resume, and CUDA process cleanup releases any remaining backups after memory pools are destroyed. ROCm remains unchanged and rejects enabling the policy.

This avoids repeated pinned-host allocation for large, interruptible model-weight workloads. It deliberately trades pinned RAM equal to backed-up allocations for faster repeated resume.

## Validation

Against current `master` (`6d5bce4`):

- CUDA 13 extensions build successfully on Python 3.14
- the CPU-backup scenario passes with both `torch` and `preload` hook modes on H100 hardware
- environment initialization passes in fresh subprocesses for both hook modes
- restoring unconditional `cudaFreeHost` on resume deterministically fails the retained active-backup assertion
- Python sources compile cleanly and `git diff --check` passes

Production validation on an 8x H100 model server:

- median weight resume: 4.846 s before, 0.623 s with retention
- five release/resume cycles completed with inference canaries and no service restart
- separate opt-in instrumentation verified 136,004,501,504 restored bytes byte-for-byte; that instrumentation is intentionally excluded from this PR
