### PR TITLE
Propagate out-of-memory from resume() instead of calling exit()

### DIFF
--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -158,9 +158,10 @@ void TorchMemorySaver::pause(const std::string& tag) {
 #endif
 }
 
-void TorchMemorySaver::resume(const std::string& tag) {
+cudaError_t TorchMemorySaver::resume(const std::string& tag) {
 #if TMS_ROCM_LEGACY_CHUNKED
     ROCmHIPImplementation::rocm_resume(tag, allocation_metadata_, allocator_metadata_mutex_);
+    return cudaSuccess;
 
 #else
     const std::lock_guard <std::mutex> lock(allocator_metadata_mutex_);
@@ -174,15 +175,20 @@ void TorchMemorySaver::resume(const std::string& tag) {
         }
 
         if (metadata.state != AllocationState::PAUSED) {
-            std::cerr << "[torch_memory_saver.cpp] Cannot resume allocation that is not paused. "
-                      << " tag=" << metadata.tag << " ptr=" << std::to_string((uintptr_t)ptr)
-                      << " file=" << __FILE__ << " func=" << __func__ << " line=" << __LINE__
-                      << std::endl;
-            exit(1);
+            // Already active. Skipping rather than aborting keeps resume()
+            // idempotent, which is what lets a caller retry after resume()
+            // returned an out-of-memory error partway through the map.
+            continue;
         }
 
         CUmemGenericAllocationHandle newAllocHandle;
-        CUDA_ERROR_CHECK(CUDAUtils::cu_mem_create(&newAllocHandle, metadata.size, metadata.device));
+        // cu_mem_create returns cudaErrorMemoryAllocation instead of aborting,
+        // precisely because the caller may be able to free memory and retry.
+        // Propagate it rather than turning it back into exit().
+        cudaError_t create_result = CUDAUtils::cu_mem_create(&newAllocHandle, metadata.size, metadata.device);
+        if (create_result != cudaSuccess) {
+            return create_result;
+        }
 
         CURESULT_CHECK(cuMemMap((CUdeviceptr) ptr, metadata.size, 0, newAllocHandle, 0));
 
@@ -213,6 +219,8 @@ void TorchMemorySaver::resume(const std::string& tag) {
         metadata.state = AllocationState::ACTIVE;
         metadata.allocHandle = newAllocHandle;
     }
+
+    return cudaSuccess;
 #endif
 }
 

--- a/csrc/core.h
+++ b/csrc/core.h
@@ -50,7 +50,7 @@ public:
     cudaError_t free(void *ptr);
 
     void pause(const std::string& tag);
-    void resume(const std::string& tag);
+    cudaError_t resume(const std::string& tag);
     void set_memory_margin_bytes(uint64_t value) {
         memory_margin_bytes_.store(value);
     }

--- a/csrc/entrypoint.cpp
+++ b/csrc/entrypoint.cpp
@@ -146,9 +146,9 @@ void tms_pause(const char* tag) {
     TorchMemorySaver::instance().pause(tag_str);
 }
 
-void tms_resume(const char* tag) {
+cudaError_t tms_resume(const char* tag) {
     std::string tag_str = (tag != nullptr) ? std::string(tag) : "";
-    TorchMemorySaver::instance().resume(tag_str);
+    return TorchMemorySaver::instance().resume(tag_str);
 }
 
 uint8_t* tms_get_cpu_backup_pointer(const uint8_t* gpu_ptr, uint64_t size) {

--- a/torch_memory_saver/binary_wrapper.py
+++ b/torch_memory_saver/binary_wrapper.py
@@ -34,6 +34,7 @@ def _setup_function_signatures(cdll):
     cdll.tms_set_disk_backup_dir.argtypes = [ctypes.c_char_p]
     cdll.tms_pause.argtypes = [ctypes.c_char_p]
     cdll.tms_resume.argtypes = [ctypes.c_char_p]
+    cdll.tms_resume.restype = ctypes.c_int
     cdll.set_memory_margin_bytes.argtypes = [ctypes.c_uint64]
     cdll.tms_get_cpu_backup_pointer.argtypes = [ctypes.POINTER(ctypes.c_uint8), ctypes.c_uint64]
     cdll.tms_get_cpu_backup_pointer.restype = ctypes.POINTER(ctypes.c_uint8)

--- a/torch_memory_saver/entrypoint.py
+++ b/torch_memory_saver/entrypoint.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 
 _TAG_DEFAULT = "default"
 
+# cudaErrorMemoryAllocation
+_CUDA_ERROR_MEMORY_ALLOCATION = 2
+
 
 class TorchMemorySaver:
     def __init__(self):
@@ -190,7 +193,15 @@ class _TorchMemorySaverImpl:
 
     def resume(self, tag: Optional[str]):
         tag_bytes = tag.encode("utf-8") if tag else None
-        self._binary_wrapper.cdll.tms_resume(tag_bytes)
+        result = self._binary_wrapper.cdll.tms_resume(tag_bytes)
+        if result == _CUDA_ERROR_MEMORY_ALLOCATION:
+            raise torch.cuda.OutOfMemoryError(
+                f"torch_memory_saver: not enough free GPU memory to resume tag={tag!r}. "
+                f"Free memory (e.g. torch.cuda.empty_cache()) and call resume() again; "
+                f"resume() skips the allocations it already restored."
+            )
+        if result != 0:
+            raise RuntimeError(f"torch_memory_saver: tms_resume(tag={tag!r}) failed with cudaError_t={result}")
 
     def get_cpu_backup(self, x: torch.Tensor, zero_copy: bool = False):
         assert x.is_cuda, f"{x.device=}"


### PR DESCRIPTION
## Problem

`CUDAUtils::cu_mem_create` deliberately treats OOM as recoverable, and says so:

```cpp
CUresult ret = cuMemCreate(alloc_handle, size, &prop, 0);
if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
    std::cerr << "[torch_memory_saver.cpp] cuMemCreate CUDA_ERROR_OUT_OF_MEMORY (may not be an issue e.g. torch allocator will free cache and retry)" << std::endl;
    return cudaErrorMemoryAllocation;
}
```

It has two call sites in `csrc/core.cpp`, and they disagree:

```cpp
// line 40, allocation path — honours the contract
cudaError_t ret = CUDAUtils::cu_mem_create(&allocHandle, size, device);
if (ret != cudaSuccess) {
    return ret;
}

// line 185, resume path — turns it back into process death
CUDA_ERROR_CHECK(CUDAUtils::cu_mem_create(&newAllocHandle, metadata.size, metadata.device));
```

`CUDA_ERROR_CHECK` calls `exit(1)`. `exit()` then runs static destructors, and torch's `CudaIPCGlobalEntities` destructor touches a CUDA context that is no longer usable, so the process dies with `SIGABRT` and **no Python traceback**:

```
Fatal Python error: Aborted

Current thread ...:
  File ".../torch_memory_saver/entrypoint.py", line 169 in resume
  ...
```

We hit this repeatedly on a 64-rank colocated RL job that pauses the inference engine's weights during training and resumes them afterwards. Under memory pressure a single rank would vanish with no diagnosis and take the whole job with it. It took a while to identify because the symptom — no traceback, no OOM in the kernel log, random timing — looks nothing like an allocation failure.

## Change

- `TorchMemorySaver::resume` returns `cudaError_t` and propagates the `cu_mem_create` failure.
- `tms_resume` forwards it.
- The Python wrapper declares `restype` and raises `torch.cuda.OutOfMemoryError` on `cudaErrorMemoryAllocation` (and `RuntimeError` otherwise), so a caller can `torch.cuda.empty_cache()` and retry — which is exactly what the allocation path already relies on.

One more change is needed for a retry to actually work. `resume()` loops over allocations, so a resume that returns partway leaves the earlier ones `ACTIVE`; the not-`PAUSED` branch used to `exit(1)` on exactly those, so the retry would abort. It now skips them, making `resume()` idempotent.

## Compatibility

The C ABI change is additive — existing callers that ignore the return value (sglang, slime, and others) keep working unchanged.

## Verified

Builds clean for CUDA 13 on aarch64, both hook modes:

```
torch_memory_saver_hook_mode_preload_cu13.abi3.so
torch_memory_saver_hook_mode_torch_cu13.abi3.so
```

Only pre-existing `-Wunused-function` warnings. I have not written a test that forces the OOM path — reproducing it needs a GPU deliberately driven to the edge of capacity — so a review of the error-path logic would be welcome.

## Out of scope

The ROCm legacy chunked path (`ROCmHIPImplementation::rocm_resume`) has its own copy of the not-`PAUSED` `exit(1)` and still returns void; `resume()` returns `cudaSuccess` after calling it. Happy to extend this to that path if you would prefer it in one PR.