### PR TITLE
Reclaim CUDA CPU-backup RSS with selectable mmap/pinned backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 **/__pycache__/
 .vscode
+.cursor/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,18 @@ torch_memory_saver.resume()
 assert tensor1[0] == 42, "content is kept unchanged"
 ```
 
-On CUDA, pinned CPU backups can be retained across resume cycles to avoid
+The default host shadow is pinned (`cpu_backup_backend="pinned"`). If process RSS remains resident after a non-retaining resume with the pinned backend, CUDA users can select `cpu_backup_backend="mmap"` (or `TMS_INIT_CPU_BACKUP_BACKEND=mmap`) so releasing the host shadow uses `munmap` instead of `cudaFreeHost`. Both backends release the host shadow on resume unless retention is enabled.
+
+```python
+with torch_memory_saver.region(enable_cpu_backup=True, cpu_backup_backend="mmap"):
+    ...
+```
+
+ROCm stays pinned (`hipHostMalloc`); `cpu_backup_backend="mmap"` is rejected. On the legacy ROCm path, host shadows are retained across resume. XPU host shadows are pageable `malloc`/`free`; `cpu_backup_backend` is not supported there.
+
+`TMS_INIT_CPU_BACKUP_BACKEND=mmap|pinned` sets the process default for preload / env-driven integrations; an explicit `cpu_backup_backend=` argument overrides it.
+
+On CUDA, pinned or mmap CPU backups can be retained across resume cycles to avoid
 reallocating them before every pause:
 
 ```python
@@ -76,11 +87,12 @@ torch_memory_saver.retain_cpu_backup = True
 ```
 
 Set `TMS_RETAIN_CPU_BACKUP=1` before process startup to enable the same policy,
-including for preload mode. Retention is CUDA-only and can consume pinned RAM
+including for preload mode. Retention is CUDA-only and can consume host RAM
 equal to the backed-up allocations. While enabled, `get_cpu_backup` continues
-to expose the retained backup after resume.
+to expose the retained backup after resume. Without retention on CUDA,
+`get_cpu_backup` is only valid while allocations are paused.
 
-The policy is consulted on resume. Setting it to `False` does not eagerly free
+The retention policy is consulted on resume. Setting it to `False` does not eagerly free
 backups for active allocations; they are released by a later non-retaining
 resume, when the allocation is freed, or when the process exits.
 

--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -21,6 +21,7 @@ cudaError_t TorchMemorySaver::malloc(
     size_t raw_size,
     const std::string& tag,
     const bool enable_cpu_backup,
+    const CpuBackupKind cpu_backup_kind,
     const bool enable_disk_backup) {
     // Enforce here, not only in the Python layer: an assert is stripped under
     // python -O and bypassed by direct C-API / env-var use.
@@ -34,6 +35,7 @@ cudaError_t TorchMemorySaver::malloc(
         raw_size,
         tag,
         enable_cpu_backup,
+        cpu_backup_kind,
         allocation_metadata_,
         allocator_metadata_mutex_);
 
@@ -73,7 +75,8 @@ cudaError_t TorchMemorySaver::malloc(
         allocation_metadata_.emplace(
             *ptr,
             AllocationMetadata{
-                raw_size, device, tag, AllocationState::ACTIVE, enable_cpu_backup, nullptr,
+                raw_size, device, tag, AllocationState::ACTIVE,
+                enable_cpu_backup, CpuBackupSlot{cpu_backup_kind, nullptr, 0},
                 enable_disk_backup, DiskBackupSlot{}, allocation_size, allocHandle}
         );
     }
@@ -117,10 +120,7 @@ cudaError_t TorchMemorySaver::free(void *ptr) {
     }
     CURESULT_CHECK(cuMemAddressFree((CUdeviceptr) ptr, metadata.allocation_size));
 
-    if (nullptr != metadata.cpu_backup) {
-        CUDA_ERROR_CHECK(cudaFreeHost(metadata.cpu_backup));
-        metadata.cpu_backup = nullptr;
-    }
+    cpu_backuper::release(metadata.cpu_backup);
 
     if (metadata.enable_disk_backup) {
         disk_backend_.release(metadata.disk);
@@ -188,12 +188,7 @@ cudaError_t TorchMemorySaver::pause(const std::string& tag) {
         }
 
         if (metadata.enable_cpu_backup) {
-            if (nullptr == metadata.cpu_backup) {
-                CUDA_ERROR_CHECK(cudaMallocHost(&metadata.cpu_backup, metadata.raw_size));
-            }
-            SIMPLE_CHECK(metadata.cpu_backup != nullptr, "cpu_backup should not be nullptr");
-            // TODO may use cudaMemcpyAsync if needed
-            CUDA_ERROR_CHECK(cudaMemcpy(metadata.cpu_backup, ptr, metadata.raw_size, cudaMemcpyDeviceToHost));
+            cpu_backuper::offload(ptr, metadata.raw_size, metadata.cpu_backup);
         } else if (metadata.enable_disk_backup) {
             disk_backend_.offload(ptr, metadata.raw_size, metadata.disk);
         }
@@ -254,13 +249,10 @@ cudaError_t TorchMemorySaver::resume(const std::string& tag) {
         CUDAUtils::cu_mem_set_access(ptr, metadata.allocation_size, metadata.device);
 
         if (metadata.enable_cpu_backup) {
-            SIMPLE_CHECK(metadata.cpu_backup != nullptr, "cpu_backup should not be nullptr");
-            // TODO may use cudaMemcpyAsync if needed
-            CUDA_ERROR_CHECK(cudaMemcpy(ptr, metadata.cpu_backup, metadata.raw_size, cudaMemcpyHostToDevice));
-
+            cpu_backuper::onload(
+                ptr, metadata.raw_size, metadata.device, metadata.cpu_backup);
             if (!retain_cpu_backup) {
-                CUDA_ERROR_CHECK(cudaFreeHost(metadata.cpu_backup));
-                metadata.cpu_backup = nullptr;
+                cpu_backuper::release(metadata.cpu_backup);
             }
         } else if (metadata.enable_disk_backup) {
             disk_backend_.onload(ptr, metadata.raw_size, metadata.disk);
@@ -303,13 +295,13 @@ uint8_t* TorchMemorySaver::get_cpu_backup_pointer(const uint8_t* query_gpu_ptr, 
                 return nullptr;
             }
             if (metadata.state == AllocationState::ACTIVE) {
-                return metadata.cpu_backup == nullptr
+                return metadata.cpu_backup.data == nullptr
                     ? nullptr
-                    : (uint8_t*) metadata.cpu_backup + offset;
+                    : (uint8_t*) metadata.cpu_backup.data + offset;
             } else {
-                SIMPLE_CHECK(nullptr != metadata.cpu_backup,
+                SIMPLE_CHECK(nullptr != metadata.cpu_backup.data,
                     "get_cpu_backup_pointer: found paused allocation but cpu_backup does not exist, do you forget to enable cpu backup");
-                return (uint8_t*) metadata.cpu_backup + offset;
+                return (uint8_t*) metadata.cpu_backup.data + offset;
             }
         }
     }

--- a/csrc/core.h
+++ b/csrc/core.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include "utils.h"
 #include "macro.h"
+#include "cpu_backup.h"
 #include "disk_backend.h"
 
 #if TMS_ROCM_LEGACY_CHUNKED
@@ -31,7 +32,7 @@ struct AllocationMetadata {
     std::string tag;
     AllocationState state;
     bool enable_cpu_backup;
-    void* cpu_backup;
+    CpuBackupSlot cpu_backup;
     bool enable_disk_backup;
     DiskBackupSlot disk;
 
@@ -60,6 +61,7 @@ public:
         size_t raw_size,
         const std::string& tag,
         bool enable_cpu_backup,
+        CpuBackupKind cpu_backup_kind,
         bool enable_disk_backup);
     cudaError_t free(void *ptr);
 

--- a/csrc/cpu_backup.h
+++ b/csrc/cpu_backup.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include "utils.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#if !defined(USE_XPU)
+#include <cerrno>
+#include <sys/mman.h>
+#endif
+
+enum class CpuBackupKind : uint8_t {
+    PINNED = 0,
+    MMAP = 1,
+};
+
+constexpr CpuBackupKind kDefaultCpuBackupKind = CpuBackupKind::PINNED;
+
+struct CpuBackupSlot {
+    CpuBackupKind kind = kDefaultCpuBackupKind;
+    void* data = nullptr;
+    size_t size = 0;
+};
+
+namespace cpu_backuper {
+
+#if defined(USE_XPU)
+
+// XPU owns host shadows with malloc/free in hardware_xpu_support.cpp and must
+// not call these CUDA/HIP helpers (kind is unused on that path).
+inline void allocate(size_t, CpuBackupSlot&) {
+    SIMPLE_CHECK(false, "cpu_backuper::allocate is not supported on XPU");
+}
+
+inline void release(CpuBackupSlot&) {
+    SIMPLE_CHECK(false, "cpu_backuper::release is not supported on XPU");
+}
+
+inline void offload(void*, size_t, CpuBackupSlot&) {
+    SIMPLE_CHECK(false, "cpu_backuper::offload is not supported on XPU");
+}
+
+inline void onload(void*, size_t, CUdevice, const CpuBackupSlot&) {
+    SIMPLE_CHECK(false, "cpu_backuper::onload is not supported on XPU");
+}
+
+#else
+
+inline void allocate(size_t size, CpuBackupSlot& slot) {
+    switch (slot.kind) {
+        case CpuBackupKind::MMAP: {
+            void* p = mmap(nullptr, size, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            if (p == MAP_FAILED) {
+                const int err = errno;
+                SIMPLE_CHECK(false,
+                             "mmap cpu_backup failed errno=" << err << " " << strerror(err));
+            }
+            slot.data = p;
+            break;
+        }
+        case CpuBackupKind::PINNED:
+            CUDA_ERROR_CHECK(cudaMallocHost(&slot.data, size));
+            SIMPLE_CHECK(slot.data != nullptr, "cudaMallocHost cpu_backup returned nullptr");
+            break;
+        default:
+            SIMPLE_CHECK(false, "unknown cpu_backup_kind=" << static_cast<int>(slot.kind));
+    }
+    slot.size = size;
+}
+
+inline void release(CpuBackupSlot& slot) {
+    if (slot.data == nullptr) {
+        return;
+    }
+    switch (slot.kind) {
+        case CpuBackupKind::MMAP: {
+            if (munmap(slot.data, slot.size) != 0) {
+                const int err = errno;
+                SIMPLE_CHECK(false,
+                             "munmap cpu_backup failed errno=" << err << " " << strerror(err));
+            }
+            break;
+        }
+        case CpuBackupKind::PINNED:
+            CUDA_ERROR_CHECK(cudaFreeHost(slot.data));
+            break;
+        default:
+            SIMPLE_CHECK(false, "unknown cpu_backup_kind=" << static_cast<int>(slot.kind));
+    }
+    slot.data = nullptr;
+    slot.size = 0;
+}
+
+inline void offload(void* gpu_ptr, size_t size, CpuBackupSlot& slot) {
+    if (slot.data == nullptr) {
+        allocate(size, slot);
+    }
+    SIMPLE_CHECK(slot.data != nullptr && slot.size == size, "cpu_backup slot size mismatch");
+    // TODO may use cudaMemcpyAsync if needed
+    CUDA_ERROR_CHECK(cudaMemcpy(slot.data, gpu_ptr, size, cudaMemcpyDeviceToHost));
+}
+
+inline void onload(void* gpu_ptr, size_t size, CUdevice device, const CpuBackupSlot& slot) {
+    SIMPLE_CHECK(slot.data != nullptr, "cpu_backup missing on resume");
+    SIMPLE_CHECK(slot.size == size, "cpu_backup slot size mismatch");
+    int original_device = -1;
+    if (slot.kind == CpuBackupKind::MMAP) {
+        CUDA_ERROR_CHECK(cudaGetDevice(&original_device));
+        CUDA_ERROR_CHECK(cudaSetDevice(static_cast<int>(device)));
+    }
+    // TODO may use cudaMemcpyAsync if needed
+    CUDA_ERROR_CHECK(cudaMemcpy(gpu_ptr, slot.data, size, cudaMemcpyHostToDevice));
+    // Pageable H2D may return after staging while DMA is still in flight.
+    if (slot.kind == CpuBackupKind::MMAP) {
+        CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+        CUDA_ERROR_CHECK(cudaSetDevice(original_device));
+    }
+}
+
+#endif
+
+}
+
+inline CpuBackupKind cpu_backup_kind_from_str(const char* value) {
+    if (value == nullptr || value[0] == '\0') {
+        return kDefaultCpuBackupKind;
+    }
+    std::string s(value);
+    if (s == "mmap") {
+#if defined(USE_ROCM) || defined(USE_XPU)
+        SIMPLE_CHECK(false, "cpu_backup_backend=mmap is not supported on this platform");
+#else
+        return CpuBackupKind::MMAP;
+#endif
+    }
+    if (s == "pinned") {
+        return CpuBackupKind::PINNED;
+    }
+    SIMPLE_CHECK(false, "cpu_backup_backend must be mmap or pinned value=" << s);
+    return kDefaultCpuBackupKind;
+}
+
+inline const char* cpu_backup_kind_to_str(CpuBackupKind kind) {
+    switch (kind) {
+        case CpuBackupKind::MMAP:
+            return "mmap";
+        case CpuBackupKind::PINNED:
+            return "pinned";
+        default:
+            SIMPLE_CHECK(false, "unknown cpu_backup_kind=" << static_cast<int>(kind));
+            return "";
+    }
+}

--- a/csrc/entrypoint.cpp
+++ b/csrc/entrypoint.cpp
@@ -3,6 +3,7 @@
 #include "api_forwarder.h"
 #include <optional>
 #include "macro.h"
+#include "cpu_backup.h"
 
 // ----------------------------------------------- threadlocal configs --------------------------------------------------
 
@@ -32,6 +33,14 @@ public:
         enable_cpu_backup_ = value;
     }
 
+    CpuBackupKind cpu_backup_kind() const {
+        return cpu_backup_kind_;
+    }
+
+    void set_cpu_backup_kind(CpuBackupKind value) {
+        cpu_backup_kind_ = value;
+    }
+
     bool enable_disk_backup() {
         if (!enable_disk_backup_.has_value()) {
             enable_disk_backup_ = get_bool_env_var("TMS_INIT_ENABLE_DISK_BACKUP");
@@ -46,6 +55,8 @@ public:
 private:
     std::optional<bool> is_interesting_region_;
     std::optional<bool> enable_cpu_backup_;
+    CpuBackupKind cpu_backup_kind_ = cpu_backup_kind_from_str(
+        std::getenv("TMS_INIT_CPU_BACKUP_BACKEND"));
     std::optional<bool> enable_disk_backup_;
 };
 static thread_local ThreadLocalConfig thread_local_config;
@@ -57,7 +68,8 @@ cudaError_t cudaMalloc(void **ptr, size_t size) {
     if (thread_local_config.is_interesting_region()) {
         return TorchMemorySaver::instance().malloc(
             ptr, CUDAUtils::cu_ctx_get_device(), size, thread_local_config.current_tag_,
-            thread_local_config.enable_cpu_backup(), thread_local_config.enable_disk_backup());
+            thread_local_config.enable_cpu_backup(), thread_local_config.cpu_backup_kind(),
+            thread_local_config.enable_disk_backup());
     } else {
         return APIForwarder::call_real_cuda_malloc(ptr, size);
     }
@@ -80,7 +92,8 @@ void *tms_torch_malloc(ssize_t size, int device, cudaStream_t stream) {
     void *ptr;
     CUDA_ERROR_CHECK(TorchMemorySaver::instance().malloc(
         &ptr, CUDAUtils::cu_device_get(device), size, thread_local_config.current_tag_,
-        thread_local_config.enable_cpu_backup(), thread_local_config.enable_disk_backup()));
+        thread_local_config.enable_cpu_backup(), thread_local_config.cpu_backup_kind(),
+        thread_local_config.enable_disk_backup()));
     return ptr;
 }
 
@@ -124,6 +137,14 @@ bool tms_get_enable_cpu_backup() {
 
 void tms_set_enable_cpu_backup(bool enable_cpu_backup) {
     thread_local_config.set_enable_cpu_backup(enable_cpu_backup);
+}
+
+const char* tms_get_cpu_backup_backend() {
+    return cpu_backup_kind_to_str(thread_local_config.cpu_backup_kind());
+}
+
+void tms_set_cpu_backup_backend(const char* backend) {
+    thread_local_config.set_cpu_backup_kind(cpu_backup_kind_from_str(backend));
 }
 
 bool tms_get_enable_disk_backup() {

--- a/csrc/hardware_amd_support.cpp
+++ b/csrc/hardware_amd_support.cpp
@@ -133,6 +133,7 @@ namespace ROCmHIPImplementation {
         size_t raw_size,
         const std::string& tag, 
         bool enable_cpu_backup,
+        CpuBackupKind cpu_backup_kind,
         std::unordered_map<void*, AllocationMetadata>& allocation_metadata,
         std::mutex& allocator_metadata_mutex
     ) {
@@ -193,7 +194,7 @@ namespace ROCmHIPImplementation {
                     tag,
                     AllocationState::ACTIVE,
                     enable_cpu_backup,
-                    nullptr,
+                    CpuBackupSlot{cpu_backup_kind, nullptr, 0},
                     false,
                     DiskBackupSlot{},
                     aligned_size,
@@ -234,10 +235,7 @@ namespace ROCmHIPImplementation {
         // Free the reserved address using stored aligned_size
         CURESULT_CHECK(hipMemAddressFree((hipDeviceptr_t)ptr, metadata.aligned_size));
 
-        if (nullptr != metadata.cpu_backup) {
-            CUDA_ERROR_CHECK(hipFreeHost(metadata.cpu_backup));
-            metadata.cpu_backup = nullptr;
-        }
+        cpu_backuper::release(metadata.cpu_backup);
 
 #ifdef TMS_DEBUG_LOG
         std::cout << "[torch_memory_saver.cpp] TorchMemorySaver.cuda_free "
@@ -275,11 +273,7 @@ namespace ROCmHIPImplementation {
 
             // Copy data to CPU backup if enabled
             if (metadata.enable_cpu_backup) {
-                if (nullptr == metadata.cpu_backup) {
-                    CUDA_ERROR_CHECK(hipMallocHost(&metadata.cpu_backup, metadata.aligned_size));
-                }
-                SIMPLE_CHECK(metadata.cpu_backup != nullptr, "cpu_backup should not be nullptr");
-                CUDA_ERROR_CHECK(cudaMemcpy(metadata.cpu_backup, ptr, metadata.aligned_size, hipMemcpyDeviceToHost));
+                cpu_backuper::offload(ptr, metadata.aligned_size, metadata.cpu_backup);
             }
 
             // Unmap and release chunks (but keep metadata for resume)
@@ -327,8 +321,8 @@ namespace ROCmHIPImplementation {
 
             // Restore from CPU backup if enabled
             if (metadata.enable_cpu_backup) {
-                SIMPLE_CHECK(metadata.cpu_backup != nullptr, "cpu_backup should not be nullptr");
-                CUDA_ERROR_CHECK(cudaMemcpy(ptr, metadata.cpu_backup, metadata.aligned_size, hipMemcpyHostToDevice));
+                cpu_backuper::onload(
+                    ptr, metadata.aligned_size, metadata.device, metadata.cpu_backup);
             }
 
             metadata.state = AllocationState::ACTIVE;

--- a/csrc/hardware_amd_support.h
+++ b/csrc/hardware_amd_support.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "macro.h"
 #include "utils.h"
+#include "cpu_backup.h"
 #include <vector>
 #include <string>
 #include <sstream>
@@ -29,6 +30,7 @@ namespace ROCmHIPImplementation {
         size_t raw_size,
         const std::string& tag, 
         bool enable_cpu_backup,
+        CpuBackupKind cpu_backup_kind,
         std::unordered_map<void*, AllocationMetadata>& allocation_metadata,
         std::mutex& allocator_metadata_mutex
     );

--- a/csrc/hardware_xpu_support.cpp
+++ b/csrc/hardware_xpu_support.cpp
@@ -160,7 +160,7 @@ cudaError_t xpu_malloc(
       metadata.tag = tag;
       metadata.state = AllocationState::ACTIVE;
       metadata.enable_cpu_backup = enable_cpu_backup;
-      metadata.cpu_backup = nullptr;
+      metadata.cpu_backup = CpuBackupSlot{};
       metadata.enable_disk_backup = false;
       metadata.aligned_size = aligned;
       metadata.xpu.ze_ctx = pdc.ze_ctx;
@@ -236,8 +236,10 @@ cudaError_t xpu_free(
     }
 
     // Fully released: only now drop ownership.
-    if (metadata.cpu_backup)
-      std::free(metadata.cpu_backup);
+    if (metadata.cpu_backup.data) {
+      std::free(metadata.cpu_backup.data);
+      metadata.cpu_backup.data = nullptr;
+    }
     XPU_LOG("free ptr=" << ptr << " size=" << metadata.raw_size);
     allocation_metadata.erase(it);
     return cudaSuccess;
@@ -264,26 +266,28 @@ cudaError_t xpu_pause(
       size_t aligned = metadata.aligned_size;
 
       if (metadata.enable_cpu_backup) {
-        if (!metadata.cpu_backup)
-          metadata.cpu_backup = std::malloc(metadata.raw_size);
-        if (!metadata.cpu_backup) {
+        if (!metadata.cpu_backup.data)
+          metadata.cpu_backup.data = std::malloc(metadata.raw_size);
+        if (!metadata.cpu_backup.data) {
           XPU_ERR("cpu backup malloc failed for ptr=" << ptr
                   << " size=" << metadata.raw_size << "; keeping ACTIVE");
           if (first_err == cudaSuccess)
             first_err = cudaErrorMemoryAllocation;
           continue;
         }
+        metadata.cpu_backup.size = metadata.raw_size;
         bool memcpy_ok = false;
         try {
           PerDeviceContext &pdc = get_device_context(metadata.device);
-          pdc.sycl_queue.memcpy(metadata.cpu_backup, ptr, metadata.raw_size).wait();
+          pdc.sycl_queue.memcpy(metadata.cpu_backup.data, ptr, metadata.raw_size).wait();
           memcpy_ok = true;
         } catch (...) {
           XPU_ERR("cpu backup memcpy failed for ptr=" << ptr << "; keeping ACTIVE");
         }
         if (!memcpy_ok) {
-          std::free(metadata.cpu_backup);
-          metadata.cpu_backup = nullptr;
+          std::free(metadata.cpu_backup.data);
+          metadata.cpu_backup.data = nullptr;
+          metadata.cpu_backup.size = 0;
           if (first_err == cudaSuccess)
             first_err = cudaErrorMemoryAllocation;
           continue;
@@ -385,13 +389,13 @@ cudaError_t xpu_resume(
         continue;
       }
 
-      if (metadata.enable_cpu_backup && metadata.cpu_backup) {
+      if (metadata.enable_cpu_backup && metadata.cpu_backup.data) {
         bool restore_ok = false;
         try {
           if (xpu_test_fault("TMS_XPU_FAULT_RESUME_RESTORE"))
             throw std::runtime_error("injected restore fault");
           PerDeviceContext &pdc = get_device_context(metadata.device);
-          pdc.sycl_queue.memcpy(ptr, metadata.cpu_backup, metadata.raw_size).wait();
+          pdc.sycl_queue.memcpy(ptr, metadata.cpu_backup.data, metadata.raw_size).wait();
           restore_ok = true;
         } catch (const std::exception &e) {
           XPU_ERR("cpu restore memcpy failed for ptr=" << ptr << ": "
@@ -412,9 +416,10 @@ cudaError_t xpu_resume(
       metadata.xpu.ze_phys = phys;
       metadata.xpu.leaked = false;
       metadata.state = AllocationState::ACTIVE;
-      if (metadata.cpu_backup) {
-        std::free(metadata.cpu_backup);
-        metadata.cpu_backup = nullptr;
+      if (metadata.cpu_backup.data) {
+        std::free(metadata.cpu_backup.data);
+        metadata.cpu_backup.data = nullptr;
+        metadata.cpu_backup.size = 0;
       }
       XPU_LOG("resume ptr=" << ptr << " size=" << metadata.raw_size
                             << " tag=" << metadata.tag);

--- a/csrc/macro.h
+++ b/csrc/macro.h
@@ -35,6 +35,8 @@
 #define cudaMemcpy hipMemcpy
 #define cudaMemGetInfo hipMemGetInfo
 #define cudaDeviceSynchronize hipDeviceSynchronize
+#define cudaGetDevice hipGetDevice
+#define cudaSetDevice hipSetDevice
 // --- Memory Copy Direction Constants ---
 #define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
 #define cudaMemcpyHostToDevice hipMemcpyHostToDevice

--- a/test/examples/cpu_backup.py
+++ b/test/examples/cpu_backup.py
@@ -1,121 +1,325 @@
 import ctypes
 import gc
 import logging
+import os
 import sys
 
 import torch
 
 from torch_memory_saver import torch_memory_saver
-from torch_memory_saver.testing_utils import get_device
+from torch_memory_saver.testing_utils import empty_cache, get_device
 
 
 def run(hook_mode: str):
     torch_memory_saver.hook_mode = hook_mode
     logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
     assert torch_memory_saver.retain_cpu_backup is False
-
     device = get_device()
 
-    print("Allocate tensor_with_backup")
-    with torch_memory_saver.region(enable_cpu_backup=True):
-        tensor_with_backup = torch.full((20_000_000,), 10, dtype=torch.uint8, device=device)
-        typed_tensor_with_backup = torch.randn((10, 20, 30), dtype=torch.float32, device=device)
-        typed_tensor_with_backup_cpu_expected = typed_tensor_with_backup.cpu()
+    # Pause/resume keeps backup contents; without backup, contents are lost.
+    # mmap is CUDA-only. ROCm default is pinned; XPU does not take a backend.
+    if device == "cuda" and not torch.version.hip:
+        backends = ["mmap", "pinned"]
+    else:
+        backends = [None]
+    for backend in backends:
+        print(f"Allocate tensor_with_backup backend={backend or 'default'}")
+        region_kwargs = dict(enable_cpu_backup=True)
+        if backend is not None:
+            region_kwargs["cpu_backup_backend"] = backend
+        with torch_memory_saver.region(**region_kwargs):
+            tensor_with_backup = torch.full((20_000_000,), 10, dtype=torch.uint8, device=device)
+            typed_tensor_with_backup = torch.randn((10, 20, 30), dtype=torch.float32, device=device)
+            typed_tensor_with_backup_cpu_expected = typed_tensor_with_backup.cpu()
 
-    print("Allocate tensor_without_backup")
-    with torch_memory_saver.region(enable_cpu_backup=False):
-        tensor_without_backup = torch.full((20_000_000,), 20, dtype=torch.uint8, device=device)
+        print("Allocate tensor_without_backup")
+        with torch_memory_saver.region(enable_cpu_backup=False):
+            tensor_without_backup = torch.full((20_000_000,), 20, dtype=torch.uint8, device=device)
 
-    print(f"{tensor_with_backup[:3]=} {tensor_without_backup[:3]=}")
-    assert tensor_with_backup[:3].tolist() == [10, 10, 10]
-    assert tensor_without_backup[:3].tolist() == [20, 20, 20]
+        assert tensor_with_backup[:3].tolist() == [10, 10, 10]
+        assert tensor_without_backup[:3].tolist() == [20, 20, 20]
 
-    torch_memory_saver.pause()
+        torch_memory_saver.pause()
+        typed_actual = torch_memory_saver.get_cpu_backup(typed_tensor_with_backup)
+        assert typed_actual is not None
+        assert torch.all(typed_tensor_with_backup_cpu_expected == typed_actual)
 
-    typed_tensor_with_backup_cpu_actual = torch_memory_saver.get_cpu_backup(typed_tensor_with_backup)
-    assert torch.all(typed_tensor_with_backup_cpu_expected == typed_tensor_with_backup_cpu_actual)
+        # occupy some space
+        tensor_unrelated = torch.full((20_000_000,), 30, dtype=torch.uint8, device=device)
+        torch_memory_saver.resume()
 
-    # occupy some space
-    tensor_unrelated = torch.full((20_000_000,), 30, dtype=torch.uint8, device=device)
+        assert tensor_with_backup[:3].tolist() == [10, 10, 10]
+        assert tensor_without_backup[:3].tolist() != [20, 20, 20]
+        # ROCm retains host backup across resume; CUDA/XPU release it.
+        if not torch.version.hip:
+            assert torch_memory_saver.get_cpu_backup(typed_tensor_with_backup) is None
 
-    torch_memory_saver.resume()
+        del tensor_with_backup, typed_tensor_with_backup, tensor_without_backup, tensor_unrelated
+        empty_cache()
 
-    print(f"{tensor_with_backup[:3]=} {tensor_without_backup[:3]=}")
-    assert tensor_with_backup[:3].tolist() == [10, 10, 10]
-    assert tensor_without_backup[:3].tolist() != [20, 20, 20]
-    assert torch_memory_saver.get_cpu_backup(tensor_with_backup) is None
+    if device == "cuda" and not torch.version.hip:
+        # Pageable H2D must finish before resume returns (non-default stream).
+        n = 64 * 1024 * 1024
+        with torch_memory_saver.region(enable_cpu_backup=True, cpu_backup_backend="mmap"):
+            restored = torch.full((n,), 7, dtype=torch.uint8, device=device)
+        torch_memory_saver.pause()
+        torch_memory_saver.resume()
+        stream = torch.cuda.Stream()
+        with torch.cuda.stream(stream):
+            out = restored.clone()
+        stream.synchronize()
+        assert int(out[0].item()) == 7
+        assert torch.all(out == 7)
+        del restored, out
+        empty_cache()
+
+        # mmap + retain: same host pointer across resume; released after non-retain resume.
+        expected = torch.arange(4096, dtype=torch.int64).remainder(251).to(torch.uint8)
+        with torch_memory_saver.region(enable_cpu_backup=True, cpu_backup_backend="mmap"):
+            retained = expected.to(device)
+        torch_memory_saver.pause()
+        first = torch_memory_saver.get_cpu_backup(retained, zero_copy=True)
+        first_ptr = first.data_ptr()
+        assert torch.equal(first, expected)
+        torch_memory_saver.retain_cpu_backup = True
+        del first
+        torch_memory_saver.resume()
+        after = torch_memory_saver.get_cpu_backup(retained, zero_copy=True)
+        assert after.data_ptr() == first_ptr
+        assert torch.equal(after, expected)
+        assert torch.equal(retained.cpu(), expected)
+        del after
+        torch_memory_saver.retain_cpu_backup = False
+        torch_memory_saver.pause()
+        torch_memory_saver.resume()
+        assert torch_memory_saver.get_cpu_backup(retained) is None
+        assert torch.equal(retained.cpu(), expected)
+        del retained
+        empty_cache()
 
     # Tags remain independent, and retained host storage is reused at the same
     # address while its bytes are refreshed. Exercise every visible device.
-    for device in range(torch.cuda.device_count()):
-        with torch.cuda.device(device):
-            selected_expected = _make_pattern(size=1024, offset=40 + device)
-            other_expected = _make_pattern(size=1024, offset=80 + device)
+    if device == "cuda" and not torch.version.hip:
+        for device_id in range(torch.cuda.device_count()):
+            with torch.cuda.device(device_id):
+                selected_expected = _make_pattern(size=1024, offset=40 + device_id)
+                other_expected = _make_pattern(size=1024, offset=80 + device_id)
 
-            with torch_memory_saver.region(tag=f"retained_{device}", enable_cpu_backup=True):
-                selected = selected_expected.to(device)
-            with torch_memory_saver.region(tag=f"other_{device}", enable_cpu_backup=True):
-                other = other_expected.to(device)
+                with torch_memory_saver.region(tag=f"retained_{device_id}", enable_cpu_backup=True):
+                    selected = selected_expected.to(device_id)
+                with torch_memory_saver.region(tag=f"other_{device_id}", enable_cpu_backup=True):
+                    other = other_expected.to(device_id)
 
-            torch_memory_saver.pause(tag=f"retained_{device}")
-            first_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
-            first_pointer = first_backup.data_ptr()
-            assert torch.equal(first_backup, selected_expected)
-            assert torch.equal(other.cpu(), other_expected)
+                torch_memory_saver.pause(tag=f"retained_{device_id}")
+                first_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+                first_pointer = first_backup.data_ptr()
+                assert torch.equal(first_backup, selected_expected)
+                assert torch.equal(other.cpu(), other_expected)
 
-            torch_memory_saver.retain_cpu_backup = True
-            assert torch_memory_saver.retain_cpu_backup is True
-            del first_backup
-            torch_memory_saver.resume(tag=f"retained_{device}")
-            retained_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
-            assert retained_backup.data_ptr() == first_pointer
-            assert torch.equal(retained_backup, selected_expected)
-            assert torch.equal(selected.cpu(), selected_expected)
-            del retained_backup
+                torch_memory_saver.retain_cpu_backup = True
+                assert torch_memory_saver.retain_cpu_backup is True
+                del first_backup
+                torch_memory_saver.resume(tag=f"retained_{device_id}")
+                retained_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+                assert retained_backup.data_ptr() == first_pointer
+                assert torch.equal(retained_backup, selected_expected)
+                assert torch.equal(selected.cpu(), selected_expected)
+                del retained_backup
 
-            torch_memory_saver.retain_cpu_backup = False
-            assert torch_memory_saver.retain_cpu_backup is False
-            retained_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
-            assert retained_backup.data_ptr() == first_pointer
-            assert torch.equal(retained_backup, selected_expected)
-            del retained_backup
+                torch_memory_saver.retain_cpu_backup = False
+                assert torch_memory_saver.retain_cpu_backup is False
+                retained_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+                assert retained_backup.data_ptr() == first_pointer
+                assert torch.equal(retained_backup, selected_expected)
+                del retained_backup
 
-            selected_expected = _make_pattern(size=1024, offset=50 + device)
-            selected.copy_(selected_expected)
-            torch_memory_saver.pause(tag=f"retained_{device}")
-            second_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
-            assert second_backup.data_ptr() == first_pointer
-            assert torch.equal(second_backup, selected_expected)
+                selected_expected = _make_pattern(size=1024, offset=50 + device_id)
+                selected.copy_(selected_expected)
+                torch_memory_saver.pause(tag=f"retained_{device_id}")
+                second_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+                assert second_backup.data_ptr() == first_pointer
+                assert torch.equal(second_backup, selected_expected)
 
-            torch_memory_saver.retain_cpu_backup = True
-            del second_backup
-            torch_memory_saver.resume(tag=f"retained_{device}")
-            retained_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
-            assert retained_backup.data_ptr() == first_pointer
-            assert torch.equal(retained_backup, selected_expected)
-            assert torch.equal(selected.cpu(), selected_expected)
-            del retained_backup
+                torch_memory_saver.retain_cpu_backup = True
+                del second_backup
+                torch_memory_saver.resume(tag=f"retained_{device_id}")
+                retained_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+                assert retained_backup.data_ptr() == first_pointer
+                assert torch.equal(retained_backup, selected_expected)
+                assert torch.equal(selected.cpu(), selected_expected)
+                del retained_backup
 
-            selected_expected = _make_pattern(size=1024, offset=60 + device)
-            selected.copy_(selected_expected)
-            torch_memory_saver.pause(tag=f"retained_{device}")
-            third_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
-            assert third_backup.data_ptr() == first_pointer
-            assert torch.equal(third_backup, selected_expected)
+                selected_expected = _make_pattern(size=1024, offset=60 + device_id)
+                selected.copy_(selected_expected)
+                torch_memory_saver.pause(tag=f"retained_{device_id}")
+                third_backup = torch_memory_saver.get_cpu_backup(selected, zero_copy=True)
+                assert third_backup.data_ptr() == first_pointer
+                assert torch.equal(third_backup, selected_expected)
 
-            torch_memory_saver.retain_cpu_backup = False
-            del third_backup
-            torch_memory_saver.resume(tag=f"retained_{device}")
-            assert torch.equal(selected.cpu(), selected_expected)
-            assert torch_memory_saver.get_cpu_backup(selected) is None
+                torch_memory_saver.retain_cpu_backup = False
+                del third_backup
+                torch_memory_saver.resume(tag=f"retained_{device_id}")
+                assert torch.equal(selected.cpu(), selected_expected)
+                assert torch_memory_saver.get_cpu_backup(selected) is None
 
-            _assert_cpu_backup_released_on_allocation_free(device=device, paused=False)
-            _assert_cpu_backup_released_on_allocation_free(device=device, paused=True)
+                _assert_cpu_backup_released_on_allocation_free(device=device_id, paused=False)
+                _assert_cpu_backup_released_on_allocation_free(device=device_id, paused=True)
 
 
 def run_retain_from_env(hook_mode: str):
     torch_memory_saver.hook_mode = hook_mode
     assert torch_memory_saver.retain_cpu_backup is True
+
+
+def run_multi_device_mmap_restore(hook_mode: str):
+    torch_memory_saver.hook_mode = hook_mode
+    tensor_size = 64 * 1024 * 1024
+    tensors: list[torch.Tensor] = []
+
+    for device_id, value in enumerate((7, 13)):
+        torch.cuda.set_device(device_id)
+        with torch_memory_saver.region(
+            tag=f"mmap_restore_{device_id}",
+            enable_cpu_backup=True,
+            cpu_backup_backend="mmap",
+        ):
+            tensors.append(
+                torch.full(
+                    (tensor_size,),
+                    value,
+                    dtype=torch.uint8,
+                    device=f"cuda:{device_id}",
+                )
+            )
+
+    for device_id in range(2):
+        torch.cuda.set_device(device_id)
+        torch_memory_saver.pause(tag=f"mmap_restore_{device_id}")
+
+    torch.cuda.set_device(0)
+    torch_memory_saver.resume()
+    assert torch.cuda.current_device() == 0
+
+    restored: list[torch.Tensor] = []
+    for device_id, (tensor, value) in enumerate(zip(tensors, (7, 13), strict=True)):
+        stream = torch.cuda.Stream(device=device_id)
+        with torch.cuda.stream(stream):
+            restored.append(tensor.clone())
+        stream.synchronize()
+        assert bool(torch.all(restored[-1] == value).item())
+
+    del tensors, restored
+    for device_id in range(2):
+        with torch.cuda.device(device_id):
+            torch.cuda.empty_cache()
+
+
+def run_backend_from_env(hook_mode: str):
+    # TMS_INIT_CPU_BACKUP_BACKEND is set by the test harness (not here).
+    torch_memory_saver.hook_mode = hook_mode
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+    assert os.environ.get("TMS_INIT_CPU_BACKUP_BACKEND") == "mmap"
+    device = get_device()
+    torch_memory_saver._ensure_initialized()
+    cdll = torch_memory_saver._impl._binary_wrapper.cdll
+    assert cdll.tms_get_cpu_backup_backend() == b"mmap"
+
+    with torch_memory_saver.region(enable_cpu_backup=True):
+        tensor = torch.full((20_000_000,), 10, dtype=torch.uint8, device=device)
+    assert cdll.tms_get_cpu_backup_backend() == b"mmap"
+
+    torch_memory_saver.pause()
+    assert torch_memory_saver.get_cpu_backup(tensor) is not None
+    torch_memory_saver.resume()
+    assert tensor[:3].tolist() == [10, 10, 10]
+    assert torch_memory_saver.get_cpu_backup(tensor) is None
+
+    del tensor
+    empty_cache()
+
+
+def run_preload_backend_from_env(hook_mode: str):
+    # Env is set by the test harness. Allocate outside region() so C++ TLS
+    # construction-time parse is what selects mmap.
+    assert hook_mode == "preload"
+    assert os.environ["TMS_INIT_ENABLE"] == "1"
+    assert os.environ["TMS_INIT_ENABLE_CPU_BACKUP"] == "1"
+    assert os.environ["TMS_INIT_CPU_BACKUP_BACKEND"] == "mmap"
+
+    tensor_bytes = 64 * 1024 * 1024
+    tolerance_bytes = int(0.25 * tensor_bytes)
+
+    def rss_bytes() -> int:
+        with open("/proc/self/status") as f:
+            return next(int(line.split()[1]) * 1024 for line in f if line.startswith("VmRSS:"))
+
+    torch_memory_saver.hook_mode = hook_mode
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+    torch_memory_saver._ensure_initialized()
+    cdll = torch_memory_saver._impl._binary_wrapper.cdll
+    assert cdll.tms_get_interesting_region()
+    assert cdll.tms_get_enable_cpu_backup()
+    assert cdll.tms_get_cpu_backup_backend() == b"mmap"
+
+    torch.cuda.synchronize()
+    tensor = torch.full((tensor_bytes,), 10, dtype=torch.uint8, device="cuda")
+    torch.cuda.synchronize()
+    rss_after_alloc = rss_bytes()
+
+    torch_memory_saver.pause()
+    torch.cuda.synchronize()
+    rss_after_pause = rss_bytes()
+    assert torch_memory_saver.get_cpu_backup(tensor) is not None
+
+    torch_memory_saver.resume()
+    torch.cuda.synchronize()
+    rss_after_resume = rss_bytes()
+    assert tensor[:3].tolist() == [10, 10, 10]
+    assert torch_memory_saver.get_cpu_backup(tensor) is None
+
+    pause_delta = rss_after_pause - rss_after_alloc
+    resume_delta = rss_after_resume - rss_after_pause
+    assert pause_delta >= tensor_bytes - tolerance_bytes, pause_delta
+    assert resume_delta <= -(tensor_bytes - tolerance_bytes), resume_delta
+
+    del tensor
+    empty_cache()
+
+
+def run_rss(hook_mode: str):
+    # mmap pause grows process RSS by ~tensor size; non-retaining resume reclaims it.
+    tensor_bytes = 2 * 1024**3
+    tolerance_bytes = int(0.25 * 1024**3)
+
+    def rss_bytes() -> int:
+        with open("/proc/self/status") as f:
+            return next(int(line.split()[1]) * 1024 for line in f if line.startswith("VmRSS:"))
+
+    torch_memory_saver.hook_mode = hook_mode
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+
+    torch.cuda.synchronize()
+    with torch_memory_saver.region(enable_cpu_backup=True, cpu_backup_backend="mmap"):
+        tensor = torch.full((tensor_bytes,), 7, dtype=torch.uint8, device="cuda")
+    torch.cuda.synchronize()
+    rss_after_alloc = rss_bytes()
+
+    torch_memory_saver.pause()
+    torch.cuda.synchronize()
+    rss_after_pause = rss_bytes()
+
+    torch_memory_saver.resume()
+    torch.cuda.synchronize()
+    rss_after_resume = rss_bytes()
+
+    assert int(tensor[0].item()) == 7
+    pause_delta = rss_after_pause - rss_after_alloc
+    resume_delta = rss_after_resume - rss_after_pause
+    assert pause_delta >= tensor_bytes - tolerance_bytes, pause_delta
+    assert resume_delta <= -(tensor_bytes - tolerance_bytes), resume_delta
+
+    del tensor
+    torch.cuda.empty_cache()
 
 
 def _assert_cpu_backup_released_on_allocation_free(device: int, paused: bool) -> None:
@@ -141,7 +345,8 @@ def _assert_cpu_backup_released_on_allocation_free(device: int, paused: bool) ->
         assert torch.equal(backup, expected)
         assert torch.equal(tensor.cpu(), expected)
 
-    pool_key = (tag, True, False, device)
+    # MemPool key includes resolved cpu_backup_backend (default pinned).
+    pool_key = (tag, True, False, "pinned", device)
     pool = torch_memory_saver._impl._mem_pools.pop(pool_key)
     torch.cuda.synchronize(device)
     del backup
@@ -149,6 +354,7 @@ def _assert_cpu_backup_released_on_allocation_free(device: int, paused: bool) ->
     with torch_memory_saver._impl._with_region_config(
         tag=tag,
         enable_cpu_backup=True,
+        cpu_backup_backend="pinned",
     ):
         del tensor
         del pool
@@ -180,5 +386,5 @@ def _make_pattern(size: int, offset: int) -> torch.Tensor:
     return torch.arange(size, dtype=torch.int64).add(offset).remainder(251).to(torch.uint8)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run(hook_mode=sys.argv[1])

--- a/test/examples/nested_region.py
+++ b/test/examples/nested_region.py
@@ -38,10 +38,12 @@ def run(hook_mode: str):
     assert cdll.tms_get_interesting_region()
     assert cdll.tms_get_enable_cpu_backup()
     assert cdll.tms_get_current_tag() == b"default"
+    assert cdll.tms_get_cpu_backup_backend() == b"pinned"
     print("✓ Initial state: interesting_region=True, cpu_backup=True, tag=default")
 
     # --- Allocate model weights (default tag, cpu_backup=True) ---
     model_weight = torch.full((SIZE,), 42.0, dtype=torch.float32, device="cuda")
+    assert cdll.tms_get_cpu_backup_backend() == b"pinned"
 
     # --- Allocate grad buffer inside nested region (cpu_backup=False) ---
     with torch_memory_saver.region(tag="grad_buffer", enable_cpu_backup=False):
@@ -49,6 +51,7 @@ def run(hook_mode: str):
         assert cdll.tms_get_interesting_region()
         assert not cdll.tms_get_enable_cpu_backup()
         assert cdll.tms_get_current_tag() == b"grad_buffer"
+        assert cdll.tms_get_cpu_backup_backend() == b"pinned"
         print("✓ Inside region: interesting_region=True, cpu_backup=False, tag=grad_buffer")
 
         grad_buffer = torch.full((SIZE,), 99.0, dtype=torch.float32, device="cuda")
@@ -57,7 +60,14 @@ def run(hook_mode: str):
     assert cdll.tms_get_interesting_region()
     assert cdll.tms_get_enable_cpu_backup()
     assert cdll.tms_get_current_tag() == b"default"
+    assert cdll.tms_get_cpu_backup_backend() == b"pinned"
     print("✓ After region: interesting_region=True, cpu_backup=True, tag=default (restored)")
+
+    if not torch.version.hip:
+        with torch_memory_saver.region(enable_cpu_backup=True, cpu_backup_backend="mmap"):
+            assert cdll.tms_get_cpu_backup_backend() == b"mmap"
+            _ = torch.full((1024,), 1, dtype=torch.uint8, device="cuda")
+        assert cdll.tms_get_cpu_backup_backend() == b"pinned"
 
     mem_before_pause = get_and_print_gpu_memory("Before pause")
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2,6 +2,7 @@ import pytest
 from contextlib import nullcontext
 
 import multiprocessing
+import sys
 import traceback
 import torch
 import torch_memory_saver
@@ -53,6 +54,52 @@ def test_cpu_backup(hook_mode):
 
 
 @_skip_on_xpu
+@_multi_device_only
+@pytest.mark.skipif(torch.version.hip is not None, reason="mmap CPU backup is CUDA-only")
+@pytest.mark.parametrize("hook_mode", _HOOK_MODES)
+def test_cpu_backup_multi_device_mmap_restore(hook_mode):
+    """Restore mmap backups on each allocation's CUDA device."""
+    _test_core(cpu_backup.run_multi_device_mmap_restore, hook_mode=hook_mode)
+
+
+@_skip_on_xpu
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or torch.version.hip is not None
+    or sys.platform != "linux",
+    reason="mmap RSS reclaim is CUDA-only; needs Linux /proc",
+)
+def test_cpu_backup_rss():
+    _test_core(cpu_backup.run_rss, hook_mode="torch")
+
+
+@_skip_on_xpu
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.version.hip is not None,
+    reason="TMS_INIT_CPU_BACKUP_BACKEND=mmap is CUDA-only",
+)
+@pytest.mark.parametrize("hook_mode", _HOOK_MODES)
+def test_cpu_backup_backend_from_env(hook_mode):
+    with change_env("TMS_INIT_CPU_BACKUP_BACKEND", "mmap"):
+        _test_core(cpu_backup.run_backend_from_env, hook_mode=hook_mode)
+
+
+@_skip_on_xpu
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or torch.version.hip is not None
+    or sys.platform != "linux",
+    reason="preload mmap env path is CUDA-only; needs Linux /proc",
+)
+def test_cpu_backup_preload_backend_from_env():
+    with (
+        change_env("TMS_INIT_ENABLE", "1"),
+        change_env("TMS_INIT_ENABLE_CPU_BACKUP", "1"),
+        change_env("TMS_INIT_CPU_BACKUP_BACKEND", "mmap"),
+    ):
+        _test_core(cpu_backup.run_preload_backend_from_env, hook_mode="preload")
+
+
 @pytest.mark.parametrize("hook_mode", _HOOK_MODES)
 def test_disk_backup(hook_mode):
     _test_core(disk_backup.run, hook_mode=hook_mode)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,7 +2,12 @@ import os
 import sys
 from types import SimpleNamespace
 
+import pytest
+import torch
+
 from torch_memory_saver import utils
+from torch_memory_saver.entrypoint import TorchMemorySaver
+from torch_memory_saver import entrypoint as entrypoint_mod
 from torch_memory_saver.utils import change_env
 
 
@@ -54,3 +59,30 @@ def test_change_env_restores_previous_value(monkeypatch):
         assert os.environ[key] == "1"
 
     assert os.environ[key] == "old"
+
+
+def test_cpu_backup_backend_requires_enable():
+    tms = TorchMemorySaver()
+    with pytest.raises(ValueError, match="requires enable_cpu_backup"):
+        with tms.region(enable_cpu_backup=False, cpu_backup_backend="mmap"):
+            pass
+
+
+def test_cpu_backup_backend_rejected_on_xpu(monkeypatch):
+    tms = TorchMemorySaver()
+    monkeypatch.setattr(entrypoint_mod, "is_xpu", lambda: True)
+    with pytest.raises(ValueError, match="not supported on XPU"):
+        with tms.region(enable_cpu_backup=True, cpu_backup_backend="pinned"):
+            pass
+    with pytest.raises(ValueError, match="not supported on XPU"):
+        with tms.region(enable_cpu_backup=True, cpu_backup_backend="mmap"):
+            pass
+
+
+def test_cpu_backup_backend_rejects_mmap_on_rocm(monkeypatch):
+    tms = TorchMemorySaver()
+    monkeypatch.setattr(entrypoint_mod, "is_xpu", lambda: False)
+    monkeypatch.setattr(torch.version, "hip", "6.2.0")
+    with pytest.raises(ValueError, match="not supported on ROCm"):
+        with tms.region(enable_cpu_backup=True, cpu_backup_backend="mmap"):
+            pass

--- a/torch_memory_saver/binary_wrapper.py
+++ b/torch_memory_saver/binary_wrapper.py
@@ -1,5 +1,6 @@
 import ctypes
 import logging
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -14,10 +15,20 @@ class BinaryWrapper:
 
         _setup_function_signatures(self.cdll)
 
-    def set_config(self, *, tag: str, interesting_region: bool, enable_cpu_backup: bool, enable_disk_backup: bool = False):
+    def set_config(
+        self,
+        *,
+        tag: str,
+        interesting_region: bool,
+        enable_cpu_backup: bool,
+        cpu_backup_backend: Optional[str] = None,
+        enable_disk_backup: bool = False,
+    ):
         self.cdll.tms_set_current_tag(tag.encode("utf-8"))
         self.cdll.tms_set_interesting_region(interesting_region)
         self.cdll.tms_set_enable_cpu_backup(enable_cpu_backup)
+        if cpu_backup_backend is not None:
+            self.cdll.tms_set_cpu_backup_backend(cpu_backup_backend.encode("utf-8"))
         self.cdll.tms_set_enable_disk_backup(enable_disk_backup)
 
 
@@ -29,6 +40,8 @@ def _setup_function_signatures(cdll):
     cdll.tms_get_interesting_region.restype = ctypes.c_bool
     cdll.tms_set_enable_cpu_backup.argtypes = [ctypes.c_bool]
     cdll.tms_get_enable_cpu_backup.restype = ctypes.c_bool
+    cdll.tms_set_cpu_backup_backend.argtypes = [ctypes.c_char_p]
+    cdll.tms_get_cpu_backup_backend.restype = ctypes.c_char_p
     cdll.tms_set_enable_disk_backup.argtypes = [ctypes.c_bool]
     cdll.tms_get_enable_disk_backup.restype = ctypes.c_bool
     cdll.tms_set_disk_backup_dir.argtypes = [ctypes.c_char_p]

--- a/torch_memory_saver/entrypoint.py
+++ b/torch_memory_saver/entrypoint.py
@@ -6,7 +6,7 @@ import logging
 import os
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Optional
+from typing import Literal, Optional
 import torch
 
 from .binary_wrapper import BinaryWrapper
@@ -16,6 +16,7 @@ from .utils import is_xpu
 logger = logging.getLogger(__name__)
 
 _TAG_DEFAULT = "default"
+CpuBackupBackend = Literal["mmap", "pinned"]
 
 
 class TorchMemorySaver:
@@ -24,20 +25,35 @@ class TorchMemorySaver:
         self._impl: Optional[_TorchMemorySaverImpl] = None
 
     @contextmanager
-    def region(self, tag: str = _TAG_DEFAULT, enable_cpu_backup: bool = False,
-               enable_disk_backup: bool = False):
+    def region(
+        self,
+        tag: str = _TAG_DEFAULT,
+        enable_cpu_backup: bool = False,
+        enable_disk_backup: bool = False,
+        cpu_backup_backend: Optional[CpuBackupBackend] = None,
+    ):
         """Context manager for memory saving with optional tag.
 
-        enable_disk_backup spills paused memory to files instead of a pinned CPU
+        enable_disk_backup spills paused memory to files instead of a CPU
         buffer; mutually exclusive with enable_cpu_backup. The target directory is
         process-global (TMS_DISK_BACKUP_DIR or set_disk_backup_dir()), not
         region-scoped, and must be a real disk mount (not tmpfs).
+
+        cpu_backup_backend selects the host shadow when enable_cpu_backup is True:
+        "pinned" (default; cudaMallocHost/hipHostMalloc) or "mmap" (reclaimable
+        RSS on CUDA). ROCm is pinned-only. XPU uses pageable malloc and does not
+        take cpu_backup_backend.
         """
+        self._validate_cpu_backup_backend(enable_cpu_backup, cpu_backup_backend)
         self._ensure_initialized()
         assert not (enable_cpu_backup and enable_disk_backup), \
             "enable_cpu_backup and enable_disk_backup are mutually exclusive"
-        with self._impl.region(tag=tag, enable_cpu_backup=enable_cpu_backup,
-                               enable_disk_backup=enable_disk_backup):
+        with self._impl.region(
+            tag=tag,
+            enable_cpu_backup=enable_cpu_backup,
+            enable_disk_backup=enable_disk_backup,
+            cpu_backup_backend=cpu_backup_backend,
+        ):
             yield
 
     @contextmanager
@@ -45,13 +61,16 @@ class TorchMemorySaver:
             self,
             cuda_graph, pool=None, stream=None, capture_error_mode='global',
             tag: str = _TAG_DEFAULT, enable_cpu_backup: bool = False,
+            cpu_backup_backend: Optional[CpuBackupBackend] = None,
     ):
         """Similar to `torch.cuda.graph`, but ensures memory in it to be pauseable."""
+        self._validate_cpu_backup_backend(enable_cpu_backup, cpu_backup_backend)
         self._ensure_initialized()
         with self._impl.cuda_graph(
                 cuda_graph=cuda_graph,
                 pool=pool, stream=stream, capture_error_mode=capture_error_mode,
                 tag=tag, enable_cpu_backup=enable_cpu_backup,
+                cpu_backup_backend=cpu_backup_backend,
         ):
             yield
 
@@ -122,6 +141,22 @@ class TorchMemorySaver:
         os.makedirs(path, exist_ok=True)
         self._impl._binary_wrapper.cdll.tms_set_disk_backup_dir(path.encode("utf-8"))
 
+    def _validate_cpu_backup_backend(
+        self,
+        enable_cpu_backup: bool,
+        cpu_backup_backend: Optional[CpuBackupBackend],
+    ) -> None:
+        if cpu_backup_backend is None:
+            return
+        if not enable_cpu_backup:
+            raise ValueError("cpu_backup_backend requires enable_cpu_backup=True")
+        if is_xpu():
+            raise ValueError(
+                "cpu_backup_backend is not supported on XPU; host shadows use malloc"
+            )
+        if cpu_backup_backend == "mmap" and torch.version.hip:
+            raise ValueError("cpu_backup_backend='mmap' is not supported on ROCm")
+
     def _ensure_initialized(self):
         if self._impl is not None:
             return
@@ -161,52 +196,108 @@ class _TorchMemorySaverImpl:
             atexit.register(self._mem_pools.clear)
 
     @contextmanager
-    def region(self, tag: str, enable_cpu_backup: bool, enable_disk_backup: bool):
+    def region(
+        self,
+        tag: str,
+        enable_cpu_backup: bool,
+        enable_disk_backup: bool,
+        cpu_backup_backend: Optional[CpuBackupBackend],
+    ):
         if self._is_xpu and enable_disk_backup:
             raise NotImplementedError(
                 "TorchMemorySaver disk backup (enable_disk_backup=True) is not "
                 "supported on Intel XPU; use enable_cpu_backup=True instead."
             )
+        # See https://github.com/fzyzcjy/torch_memory_saver/pull/20#issuecomment-3047099047
+        # Key by device too: a MemPool is bound to its creation device, so a
+        # multi-device process must not reuse one device's pool on another.
+        # Include backend so torch-mode pool reuse cannot stick the first kind.
         device = self._current_device()
-        key = (tag, enable_cpu_backup, enable_disk_backup, device)
+        resolved_cpu_backup_backend = ""
+        if enable_cpu_backup:
+            resolved_cpu_backup_backend = (
+                cpu_backup_backend
+                or self._binary_wrapper.cdll.tms_get_cpu_backup_backend().decode("utf-8")
+            )
+        key = (
+            tag,
+            enable_cpu_backup,
+            enable_disk_backup,
+            resolved_cpu_backup_backend,
+            device,
+        )
         mem_pool = self._mem_pools[key]
         with self._device_module.use_mem_pool(mem_pool):
-            with self._with_region_config(tag=tag, enable_cpu_backup=enable_cpu_backup,
-                                          enable_disk_backup=enable_disk_backup):
+            with self._with_region_config(
+                tag=tag,
+                enable_cpu_backup=enable_cpu_backup,
+                enable_disk_backup=enable_disk_backup,
+                cpu_backup_backend=cpu_backup_backend,
+            ):
                 yield
 
     def _current_device(self) -> int:
         return self._device_module.current_device()
 
     @contextmanager
-    def cuda_graph(self, cuda_graph, pool, stream, capture_error_mode, tag: str, enable_cpu_backup: bool):
+    def cuda_graph(
+        self,
+        cuda_graph,
+        pool,
+        stream,
+        capture_error_mode,
+        tag: str,
+        enable_cpu_backup: bool,
+        cpu_backup_backend: Optional[CpuBackupBackend],
+    ):
         assert self._hook_mode == "preload", "Only hook_mode=preload supports pauseable CUDA Graph currently"
         with torch.cuda.graph(cuda_graph, pool=pool, stream=stream, capture_error_mode=capture_error_mode):
-            with self._with_region_config(tag=tag, enable_cpu_backup=enable_cpu_backup):
+            with self._with_region_config(
+                tag=tag,
+                enable_cpu_backup=enable_cpu_backup,
+                cpu_backup_backend=cpu_backup_backend,
+            ):
                 yield
 
     @contextmanager
-    def _with_region_config(self, tag: str, enable_cpu_backup: bool, enable_disk_backup: bool = False):
+    def _with_region_config(
+        self,
+        tag: str,
+        enable_cpu_backup: bool,
+        cpu_backup_backend: Optional[CpuBackupBackend],
+        enable_disk_backup: bool = False,
+    ):
         cdll = self._binary_wrapper.cdll
         orig_tag = cdll.tms_get_current_tag().decode("utf-8")
         orig_interesting_region = cdll.tms_get_interesting_region()
         orig_enable_cpu_backup = cdll.tms_get_enable_cpu_backup()
+        orig_cpu_backup_backend = cdll.tms_get_cpu_backup_backend().decode("utf-8")
         orig_enable_disk_backup = cdll.tms_get_enable_disk_backup()
+        expected_cpu_backup_backend = cpu_backup_backend or orig_cpu_backup_backend
 
-        self._binary_wrapper.set_config(tag=tag, interesting_region=True,
-                                        enable_cpu_backup=enable_cpu_backup,
-                                        enable_disk_backup=enable_disk_backup)
+        self._binary_wrapper.set_config(
+            tag=tag,
+            interesting_region=True,
+            enable_cpu_backup=enable_cpu_backup,
+            cpu_backup_backend=cpu_backup_backend,
+            enable_disk_backup=enable_disk_backup,
+        )
         try:
             yield
         finally:
             assert cdll.tms_get_interesting_region()
             assert cdll.tms_get_enable_cpu_backup() == enable_cpu_backup
+            assert (
+                cdll.tms_get_cpu_backup_backend().decode("utf-8")
+                == expected_cpu_backup_backend
+            )
             assert cdll.tms_get_enable_disk_backup() == enable_disk_backup
             assert cdll.tms_get_current_tag().decode("utf-8") == tag
             self._binary_wrapper.set_config(
                 tag=orig_tag,
                 interesting_region=orig_interesting_region,
                 enable_cpu_backup=orig_enable_cpu_backup,
+                cpu_backup_backend=orig_cpu_backup_backend,
                 enable_disk_backup=orig_enable_disk_backup,
             )
 


### PR DESCRIPTION
## Summary

Closes #90.

Co-authored-by: [@akelch11](https://github.com/akelch11) (Adam Kelch).

- Default `enable_cpu_backup=True` stays **pinned** (`cudaMallocHost` / `hipHostMalloc`) — no breaking change for existing callers
- On CUDA, opt into reclaimable host RSS with `cpu_backup_backend="mmap"` or `TMS_INIT_CPU_BACKUP_BACKEND=mmap` (`munmap` on non-retaining resume)
- Backend is stored per allocation at malloc; CUDA releases the host shadow on resume unless `retain_cpu_backup` / `TMS_RETAIN_CPU_BACKUP` is set
- Unset backend TLS stays empty across env init / region push-pop (lossless restore)
- ROCm/XPU stay pinned-only (`mmap` is rejected); legacy ROCm still retains the host shadow across resume

Distinct from #86 (retain pinned backups for reuse). Here mmap is the reclaim path; pinned does not promise RSS reclaim.

Follow-ups (out of scope): #91 (`change_env` empty restore), #92 (free-while-paused), ROCm mmap reclaim.

## API

```python
# default: pinned (unchanged)
with torch_memory_saver.region(enable_cpu_backup=True):
    ...

# CUDA reclaimable RSS
with torch_memory_saver.region(enable_cpu_backup=True, cpu_backup_backend="mmap"):
    ...
```

## Validation

```
30 passed, 6 skipped in 104.29s (0:01:44)
pytest_exit=0
```

Full pytest log is in the latest comment.

### Charts

2 GiB probe and DeepSeek-V4-Flash / B300 e2e (host RSS). Images are hosted on tag `pr-89-charts` and are not in the merge tree.

![2 GiB probe](https://raw.githubusercontent.com/modal-projects/torch_memory_saver/pr-89-charts/docs/cpu_backup_rss/probe_stock_vs_mmap.png)

![Stock dual occupancy](https://raw.githubusercontent.com/modal-projects/torch_memory_saver/pr-89-charts/docs/cpu_backup_rss/e2e_dual_occupancy.png)

![Stock vs mmap host RSS](https://raw.githubusercontent.com/modal-projects/torch_memory_saver/pr-89-charts/docs/cpu_backup_rss/e2e_stock_vs_mmap.png)