### PR TITLE
Unset change_env keys that were previously absent

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,9 @@
+import os
 import sys
 from types import SimpleNamespace
 
 from torch_memory_saver import utils
+from torch_memory_saver.utils import change_env
 
 
 def _fake_torch(cuda=None, hip=None):
@@ -32,3 +34,23 @@ def test_get_binary_path_from_package_keeps_cuda_suffix_selection(monkeypatch, t
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(cuda="12.9"))
 
     assert utils.get_binary_path_from_package(stem) == binary
+
+
+def test_change_env_leaves_absent_key_absent(monkeypatch):
+    key = "TMS_TEST_CHANGE_ENV_ABSENT"
+    monkeypatch.delenv(key, raising=False)
+
+    with change_env(key, "1"):
+        assert os.environ[key] == "1"
+
+    assert key not in os.environ
+
+
+def test_change_env_restores_previous_value(monkeypatch):
+    key = "TMS_TEST_CHANGE_ENV_PRESENT"
+    monkeypatch.setenv(key, "old")
+
+    with change_env(key, "1"):
+        assert os.environ[key] == "1"
+
+    assert os.environ[key] == "old"

--- a/torch_memory_saver/utils.py
+++ b/torch_memory_saver/utils.py
@@ -97,8 +97,6 @@ def change_env(key: str, value: str):
         yield
     finally:
         assert os.environ[key] == value
-        # Restoring an absent key as "" would break consumers that reject empty
-        # values (e.g. C++ get_bool_env_var aborts on them).
         if old_value is None:
             os.environ.pop(key, None)
         else:

--- a/torch_memory_saver/utils.py
+++ b/torch_memory_saver/utils.py
@@ -90,12 +90,17 @@ def get_binary_path_from_package(stem: str):
 # private utils, not to be used by end users
 @contextmanager
 def change_env(key: str, value: str):
-    old_value = os.environ.get(key, "")
+    old_value = os.environ.get(key)
     os.environ[key] = value
     logger.debug(f"change_env set key={key} value={value}")
     try:
         yield
     finally:
         assert os.environ[key] == value
-        os.environ[key] = old_value
+        # Restoring an absent key as "" would break consumers that reject empty
+        # values (e.g. C++ get_bool_env_var aborts on them).
+        if old_value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = old_value
         logger.debug(f"change_env restore key={key} value={old_value}")


### PR DESCRIPTION
## Summary

Closes #91.

- `change_env` now tracks whether the key was absent (`None`) vs present
- On exit, absent keys are popped instead of restored as `""` (which breaks C++ `get_bool_env_var`)
- Previously set values are still restored

## Test plan

- [x] `python -m pytest test/test_utils.py` (includes absent-key and restore-value cases)