### PR TITLE
Do not release the VMM handle twice when freeing paused memory

### DIFF
--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -100,8 +100,10 @@ cudaError_t TorchMemorySaver::free(void *ptr) {
 
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 
-    CURESULT_CHECK(cuMemUnmap((CUdeviceptr) ptr, metadata.allocation_size));
-    CURESULT_CHECK(cuMemRelease(metadata.allocHandle));
+    if (AllocationState::ACTIVE == metadata.state) {
+        CURESULT_CHECK(cuMemUnmap((CUdeviceptr) ptr, metadata.allocation_size));
+        CURESULT_CHECK(cuMemRelease(metadata.allocHandle));
+    }
     CURESULT_CHECK(cuMemAddressFree((CUdeviceptr) ptr, metadata.allocation_size));
 
     if (nullptr != metadata.cpu_backup) {

--- a/csrc/hardware_amd_support.cpp
+++ b/csrc/hardware_amd_support.cpp
@@ -227,8 +227,9 @@ namespace ROCmHIPImplementation {
             allocation_metadata.erase(ptr);
         }
 
-        // Unmap and release chunks
-        cu_mem_unmap_and_release(metadata.device, metadata.aligned_size, (hipDeviceptr_t)ptr, metadata.allocHandles, metadata.chunk_sizes);
+        if (AllocationState::ACTIVE == metadata.state) {
+            cu_mem_unmap_and_release(metadata.device, metadata.aligned_size, (hipDeviceptr_t)ptr, metadata.allocHandles, metadata.chunk_sizes);
+        }
 
         // Free the reserved address using stored aligned_size
         CURESULT_CHECK(hipMemAddressFree((hipDeviceptr_t)ptr, metadata.aligned_size));

--- a/test/examples/cuda_vmm_granularity.py
+++ b/test/examples/cuda_vmm_granularity.py
@@ -1,10 +1,12 @@
 import ctypes
 import sys
 
+import torch
+
 
 _UNALIGNED_SIZE = 6912
-_CUDA_MEMCPY_HOST_TO_DEVICE = 1
-_CUDA_MEMCPY_DEVICE_TO_HOST = 2
+_MEMCPY_HOST_TO_DEVICE = 1
+_MEMCPY_DEVICE_TO_HOST = 2
 
 
 def _bind(api, name, argtypes, restype=ctypes.c_int):
@@ -14,24 +16,24 @@ def _bind(api, name, argtypes, restype=ctypes.c_int):
     return fn
 
 
-def _assert_round_trip(cuda_memcpy, ptr, expected):
+def _assert_round_trip(memcpy, ptr, expected):
     host_write = ctypes.c_ubyte(expected)
     host_read = ctypes.c_ubyte()
     assert (
-        cuda_memcpy(
+        memcpy(
             ptr,
             ctypes.byref(host_write),
             ctypes.sizeof(host_write),
-            _CUDA_MEMCPY_HOST_TO_DEVICE,
+            _MEMCPY_HOST_TO_DEVICE,
         )
         == 0
     )
     assert (
-        cuda_memcpy(
+        memcpy(
             ctypes.byref(host_read),
             ptr,
             ctypes.sizeof(host_read),
-            _CUDA_MEMCPY_DEVICE_TO_HOST,
+            _MEMCPY_DEVICE_TO_HOST,
         )
         == 0
     )
@@ -41,29 +43,41 @@ def _assert_round_trip(cuda_memcpy, ptr, expected):
 def run(hook_mode: str):
     assert hook_mode == "preload"
 
+    prefix = "hip" if torch.version.hip else "cuda"
     api = ctypes.CDLL(None)
-    cuda_malloc = _bind(
-        api, "cudaMalloc", [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
+    gpu_malloc = _bind(
+        api, f"{prefix}Malloc", [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
     )
-    cuda_memcpy = _bind(
+    gpu_memcpy = _bind(
         api,
-        "cudaMemcpy",
+        f"{prefix}Memcpy",
         [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int],
     )
-    cuda_free = _bind(api, "cudaFree", [ctypes.c_void_p])
-    cuda_set_device = _bind(api, "cudaSetDevice", [ctypes.c_int])
+    gpu_free = _bind(api, f"{prefix}Free", [ctypes.c_void_p])
+    gpu_set_device = _bind(api, f"{prefix}SetDevice", [ctypes.c_int])
     tms_pause = _bind(api, "tms_pause", [ctypes.c_char_p], None)
     tms_resume = _bind(api, "tms_resume", [ctypes.c_char_p], None)
 
-    assert cuda_set_device(0) == 0
+    assert gpu_set_device(0) == 0
     ptr = ctypes.c_void_p()
-    assert cuda_malloc(ctypes.byref(ptr), _UNALIGNED_SIZE) == 0
+    assert gpu_malloc(ctypes.byref(ptr), _UNALIGNED_SIZE) == 0
     assert ptr.value is not None
-    _assert_round_trip(cuda_memcpy, ptr, 0xA5)
+    _assert_round_trip(gpu_memcpy, ptr, 0xA5)
     tms_pause(None)
     tms_resume(None)
-    _assert_round_trip(cuda_memcpy, ptr, 0x5A)
-    assert cuda_free(ptr) == 0
+    _assert_round_trip(gpu_memcpy, ptr, 0x5A)
+    assert gpu_free(ptr) == 0
+
+    ptr_free = ctypes.c_void_p()
+    ptr_keep = ctypes.c_void_p()
+    assert gpu_malloc(ctypes.byref(ptr_free), _UNALIGNED_SIZE) == 0
+    assert gpu_malloc(ctypes.byref(ptr_keep), _UNALIGNED_SIZE) == 0
+    _assert_round_trip(gpu_memcpy, ptr_keep, 0xA5)
+    tms_pause(None)
+    assert gpu_free(ptr_free) == 0
+    tms_resume(None)
+    _assert_round_trip(gpu_memcpy, ptr_keep, 0x5A)
+    assert gpu_free(ptr_keep) == 0
 
 
 if __name__ == "__main__":

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -68,8 +68,8 @@ def test_training_engine():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.version.cuda is None,
-    reason="CUDA VMM test requires a CUDA GPU",
+    not torch.cuda.is_available(),
+    reason="VMM free-while-paused / granularity test needs a GPU",
 )
 def test_cuda_vmm_granularity():
     with change_env("TMS_INIT_ENABLE", "1"):


### PR DESCRIPTION
## Summary

Fixes #92.

`pause()` already unmaps and releases the VMM handle before marking an allocation `PAUSED`. `free()` used to do the same again, so freeing while paused double-unmapped / double-released the handle (typically aborting in `CURESULT_CHECK`).

`free()` now:
- unmaps/releases the device handle only when `ACTIVE`
- always frees the reserved VA and any CPU/disk backup

Same guard applied to the ROCm 6.x legacy chunked `rocm_free` path.

## Files

- `csrc/core.cpp` — ACTIVE-only unmap/release in `free()`
- `csrc/hardware_amd_support.cpp` — same for legacy `rocm_free`
- `test/examples/cuda_vmm_granularity.py` — extend existing preload ctypes harness with free-while-paused (no new example file; MemPool `del` is not a reliable free trigger)

## Test plan

- [x] `pytest test/test_examples.py::test_cuda_vmm_granularity -s` on Modal A10G