### PR TITLE
Skip multi-device tests when fewer than two GPUs are available

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -29,6 +29,11 @@ _HOOK_MODES = ["torch"] if _IS_XPU else ["preload", "torch"]
 # Skip reason for tests that exercise CUDA/HIP-only paths on XPU.
 _skip_on_xpu = pytest.mark.skipif(_IS_XPU, reason="CUDA/HIP-only path, not supported on XPU")
 _xpu_only = pytest.mark.skipif(not _IS_XPU, reason="XPU-specific path")
+_device_module = torch.xpu if _IS_XPU else torch.cuda
+_multi_device_only = pytest.mark.skipif(
+    _device_module.device_count() < 2,
+    reason="Multi-device test requires at least two devices",
+)
 
 
 @pytest.mark.parametrize("hook_mode", _HOOK_MODES)
@@ -54,11 +59,13 @@ def test_disk_backup(hook_mode):
 
 
 @_skip_on_xpu
+@_multi_device_only
 @pytest.mark.parametrize("hook_mode", _HOOK_MODES)
 def test_multi_device(hook_mode):
     _test_core(multi_device.run, hook_mode=hook_mode)
 
 
+@_multi_device_only
 def test_multi_device_torch_mode():
     _test_core(multi_device_torch_mode.run, hook_mode="torch")
 


### PR DESCRIPTION
## Evidence

- Host: `tom-workstation`
- Container: `pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel` via DaoCloud, image ID `sha256:7d57e307bd9c152da255651dc3458beaecf35fcdf4752fbbc14217b9be0307aa`
- GPU: `1x NVIDIA GeForce RTX 4090 D` with driver `550.163.01`
- Runtime: Python `3.11.11`, PyTorch `2.6.0+cu124`, CUDA toolkit/runtime `12.4.1` / `12.4`
- Device isolation: `CUDA_VISIBLE_DEVICES=0`
- Build: both preload and torch hook extensions built from this PR source with `TMS_CUDA_MAJOR=12 python setup.py build_ext --inplace`

Before this change, the two `test_multi_device` parameterizations failed consistently because they queried device 1:

```text
RuntimeError: device 1 is not visible (CUDA_VISIBLE_DEVICES=[0])
```

The single-GPU regression command in the PyTorch container was:

```bash
CUDA_VISIBLE_DEVICES=0 python -m pytest test -vv -ra
```

Final result:

```text
20 passed, 9 skipped in 42.80s
```

The nine skips comprise three multi-device cases that require at least two visible devices and six existing XPU-only cases. All CUDA tests supported on one GPU passed in both preload and torch hook modes. A focused `pytest -k multi_device` run also confirmed that pytest reports the three multi-device cases as skipped instead of treating the internal early return as a pass.