### PR TITLE
Add release publishing workflow

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/tms-publish-release/SKILL.md
+++ b/.claude/skills/tms-publish-release/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: tms-publish-release
+description: Use when preparing, building, validating, publishing, or verifying torch_memory_saver beta and stable releases across x86_64, aarch64, CUDA 12, and CUDA 13.
+---
+
+# 1 Release contract
+
+- Work from the repository root and publish only a clean commit already merged into the latest `origin/master`.
+- Use canonical PEP 440 versions in `setup.py`:
+    - Beta: `0.0.10b1`, not `0.0.10.beta-1`, `0.0.10-beta.1`, or `0.0.10beta1`.
+    - Release candidate: `0.0.10rc1`.
+    - Stable: `0.0.10`.
+    - Post release: `0.0.10.post1` only for a source-equivalent packaging correction.
+- Publish exactly three distributions:
+    - `cp39-abi3-manylinux2014_x86_64` wheel.
+    - `cp39-abi3-manylinux2014_aarch64` wheel.
+    - Source distribution.
+- Build and test on `tom-workstation`.
+- Publish from the local controller.
+- Never persist PyPI credentials on the GPU host.
+- Treat PyPI upload and Git tag push as irreversible.
+- Complete the Section 7 confirmation gate before either action.
+
+# 2 Preflight
+
+## 2.1 Repository and version
+
+```bash
+git fetch origin master
+git status --short --branch
+git rev-parse HEAD
+git rev-parse origin/master
+git diff --stat origin/master...HEAD
+```
+
+- Stop if the tree is dirty, `HEAD` differs from `origin/master`, or the release commit is detached.
+- Read and validate the version without importing `setup.py`:
+
+```bash
+uv run --script .claude/skills/tms-publish-release/scripts/release_checks.py version \
+  --setup-py setup.py \
+  --expected-version <VERSION>
+```
+
+- Confirm the target version does not already exist on PyPI:
+
+```bash
+uv run --script .claude/skills/tms-publish-release/scripts/release_checks.py pypi \
+  --expected-version <VERSION>
+```
+
+- Review every change since the previous release commit.
+- Use `c29087a58db9d120b3e69623714c5dd043029d77` as the historical source baseline for the first tagged release after `0.0.9.post1`.
+- Use the previous release tag after the first tagged release.
+
+## 2.2 Host and credential checks
+
+```bash
+ssh tom-workstation 'curl --retry 5 --retry-delay 1 --retry-all-errors -x http://127.0.0.1:7890 -I --max-time 20 https://registry-1.docker.io/v2/'
+ssh tom-workstation 'test -x /home/tom/.local/bin/uv; nvidia-smi --query-gpu=index,name,driver_version,memory.total,memory.used,utilization.gpu --format=csv,noheader; docker version; df -h / /home/tom'
+/usr/bin/stat -f '%N mode=%Lp size=%z' "$HOME/.pypirc"
+```
+
+- Expect HTTP `401` from the Docker Hub registry probe; it proves official registry reachability.
+- Stop if GPU 0 is busy, Docker is unavailable, or the host lacks enough space for the PyTorch builder images.
+- Require local `$HOME/.pypirc` mode `0600`.
+- Never print `$HOME/.pypirc`.
+- Never copy it to `tom-workstation`.
+- Never mount it into a long-lived container.
+
+## 2.3 ARM64 emulation on the x86_64 host
+
+- The official `manylinuxaarch64-builder` images are Linux ARM64 images, not x86 cross-compiler images.
+- Check for an existing ARM64 binfmt handler:
+
+```bash
+ssh tom-workstation 'test -r /proc/sys/fs/binfmt_misc/qemu-aarch64 && cat /proc/sys/fs/binfmt_misc/qemu-aarch64'
+```
+
+- If it is missing, stop for approval before installing QEMU binfmt.
+- Treat installation as privileged and host-wide.
+- Use the pinned `tonistiigi/binfmt` image.
+- After approval, install only ARM64 and verify it with an ARM64 Alpine container:
+
+```bash
+ssh tom-workstation 'docker run --privileged --rm tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install arm64
+cat /proc/sys/fs/binfmt_misc/qemu-aarch64
+docker run --rm --platform linux/arm64 alpine:3.22 uname -m'
+```
+
+- Require the smoke test to print `aarch64`.
+- Treat binfmt as boot-scoped unless the host has an explicit persistent registration. Recheck this section after every workstation reboot.
+
+## 2.4 Release script roles
+
+| Script | Responsibility | Mutates release state |
+| --- | --- | --- |
+| `.claude/skills/tms-publish-release/scripts/release_checks.py` | `version`, `pypi`, `sdist`, `artifacts`, and `publish-preflight` gates | No |
+| `.claude/skills/tms-publish-release/scripts/gpu_validation.py` | Four-cell fresh-container GPU runtime harness | Creates only temporary validation resources |
+
+- Keep upload, tag creation, and GitHub Release creation outside both scripts.
+- Use `sdist` only for focused diagnostics.
+- Use `artifacts` for the canonical release workflow after all three distributions exist.
+
+# 3 Prepare isolated paths
+
+```bash
+export TMS_RELEASE_VERSION=<VERSION>
+export TMS_RELEASE_SHA="$(git rev-parse --short=12 HEAD)"
+export TMS_RELEASE_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+export TMS_REMOTE_ROOT="/home/tom/workspace/torch_memory_saver_release_${TMS_RELEASE_VERSION}_${TMS_RELEASE_SHA}_${TMS_RELEASE_RUN_ID}"
+export TMS_REMOTE_ARTIFACTS="${TMS_REMOTE_ROOT}_artifacts"
+export TMS_LOCAL_ARTIFACTS="/Users/tom/domains/human/others/artifacts/torch_memory_saver/${TMS_RELEASE_VERSION}-${TMS_RELEASE_SHA}-${TMS_RELEASE_RUN_ID}-release"
+mkdir "$TMS_LOCAL_ARTIFACTS"
+ssh tom-workstation "test ! -e '$TMS_REMOTE_ROOT' && test ! -e '$TMS_REMOTE_ARTIFACTS' && mkdir '$TMS_REMOTE_ROOT' '$TMS_REMOTE_ARTIFACTS'"
+rsync -a \
+  --exclude .git \
+  --exclude build \
+  --exclude dist \
+  --exclude torch_memory_saver.egg-info \
+  --exclude .pytest_cache \
+  --exclude '*.so' \
+  ./ "tom-workstation:$TMS_REMOTE_ROOT/"
+shasum -a 256 setup.py
+ssh tom-workstation "sha256sum '$TMS_REMOTE_ROOT/setup.py'"
+```
+
+- Do not use `rsync --delete`.
+- **Isolation**: Never reuse a remote source or artifact directory, even for the same version and commit.
+    - The fail-if-present `mkdir` and run ID make every rehearsal independent.
+- **Logs**: Put every build, validation, and environment log in the unique remote artifact directory.
+
+# 4 Build release distributions
+
+## 4.1 x86_64 wheel
+
+- Build with the official PyTorch CUDA 12.8 and CUDA 13.0 manylinux images.
+
+```bash
+ssh tom-workstation "cd '$TMS_REMOTE_ROOT' \
+  && make clean \
+  && TMS_PYTHON_BUILD_IMAGE=python:3.11 make build-wheel-multi-cuda \
+  > '$TMS_REMOTE_ARTIFACTS/build-x86_64.log' 2>&1"
+```
+
+- Run long commands in a background exec session and babysit with:
+
+```bash
+ssh tom-workstation "tail -80 '$TMS_REMOTE_ARTIFACTS/build-x86_64.log'"
+```
+
+## 4.2 aarch64 wheel on the x86_64 host
+
+- Build with the official ARM64 PyTorch CUDA 12.8 and CUDA 13.0 manylinux images.
+
+```bash
+ssh tom-workstation "cd '$TMS_REMOTE_ROOT' \
+  && rm -rf build torch_memory_saver.egg-info \
+  && DOCKER_DEFAULT_PLATFORM=linux/arm64 \
+    TMS_PYTHON_BUILD_IMAGE=python:3.11 \
+    make build-wheel-multi-cuda-aarch64 \
+  > '$TMS_REMOTE_ARTIFACTS/build-aarch64.log' 2>&1"
+```
+
+## 4.3 Source distribution and artifact gate
+
+```bash
+ssh tom-workstation "cd '$TMS_REMOTE_ROOT' \
+  && TMS_PYTHON_BUILD_IMAGE=python:3.11 make build-sdist \
+  > '$TMS_REMOTE_ARTIFACTS/build-sdist.log' 2>&1 \
+  && HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0.1:7890 \
+    /home/tom/.local/bin/uv run --script .claude/skills/tms-publish-release/scripts/release_checks.py artifacts \
+    --dist-dir dist \
+    --expected-version '$TMS_RELEASE_VERSION' \
+    --repo-root . \
+  > '$TMS_REMOTE_ARTIFACTS/validate-artifacts.log' 2>&1"
+```
+
+```text
+Input: $TMS_REMOTE_ROOT/dist
+Exact set: x86_64 wheel, aarch64 wheel, sdist
+Wheel gate:
+  - Filename and internal metadata tags
+  - ELF machine for every binary
+  - CUDA 12 and CUDA 13 binary families
+  - Unsuffixed CUDA 12 compatibility binaries
+  - RECORD integrity
+Sdist gate: canonical version, metadata, complete native sources
+Ownership: dist, build, and torch_memory_saver.egg-info belong to the SSH user
+Failure policy: stop on any mismatch or extra artifact
+```
+
+# 5 Validate both wheels in fresh GPU containers
+
+## 5.1 Harness specification
+
+| Case | Runtime path |
+| --- | --- |
+| x86_64 CUDA 12 | PyTorch CUDA 12 container, direct NVIDIA runtime |
+| x86_64 CUDA 13 | PyTorch CUDA 13 container, direct NVIDIA runtime |
+| ARM64 CUDA 12 | Official Lupine 12.8.1 PyTorch worker under QEMU to matched x86 server |
+| ARM64 CUDA 13 | Official Lupine 13.0.2 PyTorch worker under QEMU to matched x86 server |
+
+### 5.1.1 Common contract
+
+```text
+Host: x86_64 tom-workstation
+Inputs: final x86_64 wheel, final aarch64 wheel, runtime tests only
+Image acquisition: docker run --pull missing
+Source mount: release root at /workspace, read-only
+Install root: final wheel into site-packages or dist-packages
+Test root: /validation, outside the source checkout
+x86_64 test suite: full single-GPU runtime pytest
+ARM64 test suite: runtime pytest with the exact Lupine deselections below
+Lupine deselection 1: test/test_examples.py::test_cpu_backup_preload_backend_from_env
+Lupine deselection 2: test/test_examples.py::test_disk_backup[preload]
+Lupine deselection 3: test/test_examples.py::test_disk_backup[torch]
+CUDA major: matches the matrix cell
+CUDA availability: torch.cuda.is_available() is true
+GPU identity: NVIDIA GeForce RTX 4090 D
+CUDA runtime: matching packaged libcudart added before preload children start
+Process architecture: matches the matrix cell
+Binary architecture: every loaded ELF machine matches the matrix cell
+Inventory gate: every repository test_*.py classified as runtime or build tooling
+Build-tool UT: build phase only
+Success: zero failures in all four cells
+Allowed skips: single-GPU multi-device cases and XPU-only cases
+Skip review: inspect every reason
+Additional skip or deselection: forbidden
+Evidence: image identity, environment, commands, installed paths, binaries, pytest output
+Cleanup: named clients, servers, containers, and private networks removed on success or failure
+```
+
+### 5.1.2 Lupine contract
+
+```text
+Matrix source: .claude/skills/tms-publish-release/scripts/gpu_validation.py
+Image identity: architecture-specific worker/server refs pinned by digest
+Worker: official ARM64 lupine-pytorch-worker
+Server: official x86_64 lupine-server with GPU 0 attached
+Source revision: ebf4c2784e5756891ed8c2439fec37ed1a4e6b51 for worker and server
+Network: private per-cell bridge; RPC port not published to the workstation LAN
+Proxy: host.docker.internal:host-gateway -> workstation Clash
+Preinstalled: ARM Python, PyTorch, CUDA user-space libraries, CUDA/NVML shims
+Added test dependencies: pinned binary NumPy, pytest, nvidia-ml-py wheels
+Execution: real ARM64 Python, PyTorch, and TMS wheel under QEMU
+GPU path: CUDA driver and NVML calls forwarded to the physical 4090D
+Qualification: ARM user-space GPU behavior through Lupine
+Not qualified: ARM NVIDIA kernel driver or native ARM PCIe path
+Disk-backup boundary: Lupine protects pinned host mirrors read-only, so kernel pread returns EFAULT
+RSS boundary: Lupine first-transfer buffers invalidate the preload RSS delta assertion
+Product-code workaround: forbidden; keep both behaviors covered by the direct x86_64 cells
+Derived client image: forbidden
+```
+
+## 5.2 Run the harness
+
+```bash
+ssh tom-workstation "HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0.1:7890 \
+  /home/tom/.local/bin/uv run --script \
+  '$TMS_REMOTE_ROOT/.claude/skills/tms-publish-release/scripts/gpu_validation.py' \
+  --release-root '$TMS_REMOTE_ROOT' \
+  --artifact-root '$TMS_REMOTE_ARTIFACTS' \
+  --expected-version '$TMS_RELEASE_VERSION'"
+```
+
+# 6 Pull and recheck artifacts locally
+
+```bash
+rsync -a "tom-workstation:$TMS_REMOTE_ARTIFACTS/" "$TMS_LOCAL_ARTIFACTS/"
+rsync -a "tom-workstation:$TMS_REMOTE_ROOT/dist/" "$TMS_LOCAL_ARTIFACTS/dist/"
+uv run --script .claude/skills/tms-publish-release/scripts/release_checks.py artifacts \
+  --dist-dir "$TMS_LOCAL_ARTIFACTS/dist" \
+  --expected-version "$TMS_RELEASE_VERSION" \
+  --repo-root .
+shasum -a 256 "$TMS_LOCAL_ARTIFACTS"/dist/*
+UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine \
+  python -m twine check "$TMS_LOCAL_ARTIFACTS"/dist/*
+```
+
+- Do not upload directly from the remote build directory.
+- Keep all three distribution files and full logs at the permanent local artifact path.
+
+# 7 Publish
+
+- Present the release evidence to the human:
+    - Exact version.
+    - Full release SHA.
+    - Three filenames and SHA-256 hashes.
+    - Four fresh-container GPU results.
+    - Explicit Lupine qualification boundary.
+- Continue only after explicit confirmation.
+- Re-fetch `origin/master` and repeat the clean-tree and exact-SHA checks immediately before upload.
+- Recheck every immutable release namespace:
+
+```bash
+uv run --script .claude/skills/tms-publish-release/scripts/release_checks.py publish-preflight \
+  --expected-version "$TMS_RELEASE_VERSION" \
+  --remote origin \
+  --repository fzyzcjy/torch_memory_saver
+```
+
+- Treat an existing PyPI version, remote `v<VERSION>` tag, or GitHub Release as a hard failure.
+- Treat network and authentication errors as hard failures.
+- Upload without `--skip-existing`; a collision is a hard failure:
+
+```bash
+UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine \
+  python -m twine upload --non-interactive --repository pypi "$TMS_LOCAL_ARTIFACTS"/dist/*
+```
+
+- Poll PyPI with bounded waits until all three files appear under the exact version.
+- Create an annotated tag and prerelease only after PyPI confirms the version:
+
+```bash
+git tag -a "v$TMS_RELEASE_VERSION" -m "Release $TMS_RELEASE_VERSION" "$(git rev-parse HEAD)"
+git push origin "v$TMS_RELEASE_VERSION"
+gh release create "v$TMS_RELEASE_VERSION" \
+  --repo fzyzcjy/torch_memory_saver \
+  --verify-tag \
+  --prerelease \
+  --generate-notes \
+  "$TMS_LOCAL_ARTIFACTS"/dist/*
+```
+
+- Omit `--prerelease` for a stable release.
+- Never reuse or move a published version tag.
+
+# 8 Post-release verification
+
+```bash
+curl -fsSL "https://pypi.org/pypi/torch-memory-saver/$TMS_RELEASE_VERSION/json"
+python -m pip install --pre "torch_memory_saver==$TMS_RELEASE_VERSION"
+gh release view "v$TMS_RELEASE_VERSION" --repo fzyzcjy/torch_memory_saver
+```
+
+- Verify PyPI lists both wheels and the sdist with the recorded hashes.
+- Run an install smoke test in a fresh CUDA 12 environment; use `--pre` for beta or RC versions.
+- Report any partial release state explicitly.
+- Never delete a published PyPI version to make a retry look clean.
+- Increment the prerelease number for a retry.
+
+# 9 Reliability
+
+| Symptom | Cause | Action |
+| --- | --- | --- |
+| Docker Hub pull resets or refuses | Docker daemon is not using `tms-clash-main`, or the selected Clash node is unhealthy | Repair the daemon proxy or refresh the remote Clash config; do not switch registries |
+| ARM container reports `exec format error` | `qemu-aarch64` binfmt is absent | Stop; request approval for the privileged binfmt bootstrap |
+| Lupine client cannot reach the server | Server startup, Docker network, or matched CUDA pair is wrong | Inspect the cell log; keep the private network and use the exact client/server pair from the matrix |
+| ARM PyTorch reports no GPU | The Lupine shim is not first in the client library path or the server lacks the GPU mount | Require `/opt/lupine/lib` in `LD_LIBRARY_PATH`, `LUPINE_SERVER=<container>:14833`, and `--gpus device=0` only on the server |
+| ARM and server CUDA tags differ | Client and server protocol/runtime behavior is not the validated pair | Stop and use exactly matched Lupine tags; never mix CUDA 12 and CUDA 13 endpoints |
+| ARM validation starts downloading PyTorch | The harness is using a generic client or builder instead of the published worker | Stop and use the digest-pinned `lupine-pytorch-worker`; only NumPy, pytest, and `nvidia-ml-py` should be installed before the final TMS wheel |
+| ARM NumPy/pytest install cannot reach `127.0.0.1:7890` | Loopback inside the private-network client is the client itself | Add `host.docker.internal:host-gateway` and use `http://host.docker.internal:7890` inside the ARM client |
+| `make build-sdist` cannot import `setuptools` | The sdist ran against an unprepared host Python | Use the repository's containerized target with `TMS_PYTHON_BUILD_IMAGE=python:3.11` |
+| `make clean` reports `Permission denied` under `dist/` | An older build left root-owned bind-mount output | Remove only the dedicated rehearsal output through a root Docker container, then use the current scripts that normalize ownership |
+| Wheel test imports `/workspace/torch_memory_saver` | Pytest ran against the source tree | Copy only `test/` to `/validation` and rerun against the installed wheel |
+| CUDA 13 preload tests report `libcudart.so.13` missing | The runtime image installs CUDART under Python `site-packages/nvidia/cu13/lib` without registering it in `ldconfig` | Discover the matching CUDART path before pytest and export it through `LD_LIBRARY_PATH`; do not skip preload tests |
+| `dist/` has extra wheels | Stale or partial build output | Stop and start a new run directory; never repair or reuse a release tree |
+| PyPI upload reports an existing filename | Version or artifact was already published | Stop; never use `--skip-existing` or overwrite a release |

--- a/.claude/skills/tms-publish-release/SKILL.md
+++ b/.claude/skills/tms-publish-release/SKILL.md
@@ -24,7 +24,8 @@ description: Use when preparing, building, validating, publishing, or verifying 
 # 2 Prepare isolated paths
 
 ```bash
-export TMS_RELEASE_VERSION=<VERSION>
+set -euxo pipefail
+export TMS_RELEASE_VERSION="<VERSION>"
 export TMS_RELEASE_SHA="$(git rev-parse --short=12 HEAD)"
 export TMS_RELEASE_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
 export TMS_REMOTE_ROOT="/home/tom/workspace/torch_memory_saver_release_${TMS_RELEASE_VERSION}_${TMS_RELEASE_SHA}_${TMS_RELEASE_RUN_ID}"
@@ -44,6 +45,7 @@ mkdir "$TMS_LOCAL_ARTIFACTS"
 - Append every command, complete output, and exit result to `release-preflight.log`:
 
 ```bash
+set -euxo pipefail
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- git fetch origin master
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- git status --short --branch
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- git rev-parse HEAD
@@ -55,6 +57,7 @@ uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/relea
 - Read and validate the version without importing `setup.py`:
 
 ```bash
+set -euxo pipefail
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
   uv run --script "$TMS_RELEASE_CHECKS" version \
   --setup-py setup.py \
@@ -64,6 +67,7 @@ uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/relea
 - Confirm the target version does not already exist on PyPI:
 
 ```bash
+set -euxo pipefail
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
   uv run --script "$TMS_RELEASE_CHECKS" pypi \
   --expected-version "$TMS_RELEASE_VERSION"
@@ -76,10 +80,11 @@ uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/relea
 ## 3.2 Host and credential checks
 
 ```bash
+set -euxo pipefail
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
-  ssh tom-workstation 'curl --retry 5 --retry-delay 1 --retry-all-errors -x http://127.0.0.1:7890 -I --max-time 20 https://registry-1.docker.io/v2/'
+  ssh tom-workstation 'set -euxo pipefail; curl --retry 5 --retry-delay 1 --retry-all-errors -x http://127.0.0.1:7890 -I --max-time 20 https://registry-1.docker.io/v2/'
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
-  ssh tom-workstation 'test -x /home/tom/.local/bin/uv; nvidia-smi --query-gpu=index,name,driver_version,memory.total,memory.used,utilization.gpu --format=csv,noheader; docker version; df -h / /home/tom'
+  ssh tom-workstation 'set -euxo pipefail; test -x /home/tom/.local/bin/uv; nvidia-smi --query-gpu=index,name,driver_version,memory.total,memory.used,utilization.gpu --format=csv,noheader; docker version; df -h / /home/tom'
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
   /usr/bin/stat -f '%N mode=%Lp size=%z' "$HOME/.pypirc"
 ```
@@ -97,8 +102,9 @@ uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/relea
 - Check for an existing ARM64 binfmt handler:
 
 ```bash
+set -euxo pipefail
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
-  ssh tom-workstation 'test -r /proc/sys/fs/binfmt_misc/qemu-aarch64 && cat /proc/sys/fs/binfmt_misc/qemu-aarch64'
+  ssh tom-workstation 'set -euxo pipefail; test -r /proc/sys/fs/binfmt_misc/qemu-aarch64; cat /proc/sys/fs/binfmt_misc/qemu-aarch64'
 ```
 
 - If it is missing, stop for approval before installing QEMU binfmt.
@@ -107,8 +113,10 @@ uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/relea
 - After approval, install only ARM64 and verify it with an ARM64 Alpine container:
 
 ```bash
+set -euxo pipefail
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
-  ssh tom-workstation 'docker run --privileged --rm tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install arm64
+  ssh tom-workstation 'set -euxo pipefail
+docker run --privileged --rm tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install arm64
 cat /proc/sys/fs/binfmt_misc/qemu-aarch64
 docker run --rm --platform linux/arm64 alpine:3.22 uname -m'
 ```
@@ -120,19 +128,21 @@ docker run --rm --platform linux/arm64 alpine:3.22 uname -m'
 
 | Script | Responsibility | Mutates release state |
 | --- | --- | --- |
-| `.claude/skills/tms-publish-release/scripts/release_checks.py` | Version, namespace, artifact, manifest, publish-preflight, and append-only command-log gates | No |
+| `.claude/skills/tms-publish-release/scripts/release_checks.py` | Version, namespace, artifact, manifest, one-command pre-upload, and append-only command-log gates | No |
 | `.claude/skills/tms-publish-release/scripts/gpu_validation.py` | Four-cell fresh-container GPU runtime harness with exact skip enforcement | Creates only temporary validation resources |
 | `.claude/skills/tms-publish-release/scripts/pytest_skip_gate.py` | Exact pytest skipped-node and reason validator loaded by the harness | No |
+| `.claude/skills/tms-publish-release/scripts/verify_published_release.sh` | Auditable post-release PyPI, GitHub, CUDA 12, and CUDA 13 verification | Creates only temporary validation containers |
 
-- Keep upload, tag creation, and GitHub Release creation outside both scripts.
+- Keep upload, tag creation, and GitHub Release creation outside every release script.
 - Use `sdist` only for focused diagnostics.
 - Use `artifacts` for the canonical release workflow after all three distributions exist.
 
 ## 3.5 Create and synchronize the remote source tree
 
 ```bash
+set -euxo pipefail
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
-  ssh tom-workstation "test ! -e '$TMS_REMOTE_ROOT' && test ! -e '$TMS_REMOTE_ARTIFACTS' && mkdir '$TMS_REMOTE_ROOT' '$TMS_REMOTE_ARTIFACTS'"
+  ssh tom-workstation "set -euxo pipefail; test ! -e '$TMS_REMOTE_ROOT'; test ! -e '$TMS_REMOTE_ARTIFACTS'; mkdir '$TMS_REMOTE_ROOT' '$TMS_REMOTE_ARTIFACTS'"
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
   rsync -a \
   --exclude .git \
@@ -144,7 +154,7 @@ uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/relea
   ./ "tom-workstation:$TMS_REMOTE_ROOT/"
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- shasum -a 256 setup.py
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
-  ssh tom-workstation "sha256sum '$TMS_REMOTE_ROOT/setup.py'"
+  ssh tom-workstation "set -euxo pipefail; sha256sum '$TMS_REMOTE_ROOT/setup.py'"
 ```
 
 - Do not use `rsync --delete`.
@@ -158,7 +168,8 @@ uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/relea
 - Build with the official PyTorch CUDA 12.8 and CUDA 13.0 manylinux images.
 
 ```bash
-ssh tom-workstation "cd '$TMS_REMOTE_ROOT' \
+set -euxo pipefail
+ssh tom-workstation "set -euxo pipefail; cd '$TMS_REMOTE_ROOT' \
   && make clean \
   && TMS_PYTHON_BUILD_IMAGE=python:3.11 make build-wheel-multi-cuda \
   > '$TMS_REMOTE_ARTIFACTS/build-x86_64.log' 2>&1"
@@ -167,7 +178,8 @@ ssh tom-workstation "cd '$TMS_REMOTE_ROOT' \
 - Run long commands in a background exec session and babysit with:
 
 ```bash
-ssh tom-workstation "tail -80 '$TMS_REMOTE_ARTIFACTS/build-x86_64.log'"
+set -euxo pipefail
+ssh tom-workstation "set -euxo pipefail; tail -80 '$TMS_REMOTE_ARTIFACTS/build-x86_64.log'"
 ```
 
 ## 4.2 aarch64 wheel on the x86_64 host
@@ -175,7 +187,8 @@ ssh tom-workstation "tail -80 '$TMS_REMOTE_ARTIFACTS/build-x86_64.log'"
 - Build with the official ARM64 PyTorch CUDA 12.8 and CUDA 13.0 manylinux images.
 
 ```bash
-ssh tom-workstation "cd '$TMS_REMOTE_ROOT' \
+set -euxo pipefail
+ssh tom-workstation "set -euxo pipefail; cd '$TMS_REMOTE_ROOT' \
   && rm -rf build torch_memory_saver.egg-info \
   && DOCKER_DEFAULT_PLATFORM=linux/arm64 \
     TMS_PYTHON_BUILD_IMAGE=python:3.11 \
@@ -186,7 +199,8 @@ ssh tom-workstation "cd '$TMS_REMOTE_ROOT' \
 ## 4.3 Source distribution and artifact gate
 
 ```bash
-ssh tom-workstation "cd '$TMS_REMOTE_ROOT' \
+set -euxo pipefail
+ssh tom-workstation "set -euxo pipefail; cd '$TMS_REMOTE_ROOT' \
   && TMS_PYTHON_BUILD_IMAGE=python:3.11 make build-sdist \
   > '$TMS_REMOTE_ARTIFACTS/build-sdist.log' 2>&1 \
   && HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0.1:7890 \
@@ -283,7 +297,8 @@ Server evidence: complete Lupine server output captured with docker logs before 
 ## 5.2 Run the harness
 
 ```bash
-ssh tom-workstation "HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0.1:7890 \
+set -euxo pipefail
+ssh tom-workstation "set -euxo pipefail; HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0.1:7890 \
   /home/tom/.local/bin/uv run --script \
   '$TMS_REMOTE_ROOT/.claude/skills/tms-publish-release/scripts/gpu_validation.py' \
   --release-root '$TMS_REMOTE_ROOT' \
@@ -294,6 +309,7 @@ ssh tom-workstation "HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0
 # 6 Pull and recheck artifacts locally
 
 ```bash
+set -euxo pipefail
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/local-recheck.log" -- \
   rsync -a "tom-workstation:$TMS_REMOTE_ARTIFACTS/" "$TMS_LOCAL_ARTIFACTS/"
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/local-recheck.log" -- \
@@ -304,7 +320,7 @@ uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/local
   --expected-version "$TMS_RELEASE_VERSION" \
   --repo-root .
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/local-recheck.log" -- \
-  zsh -lc 'UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine python -m twine check "$TMS_LOCAL_ARTIFACTS"/dist/*'
+  zsh -lc 'set -euxo pipefail; UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine python -m twine check "$TMS_LOCAL_ARTIFACTS"/dist/*'
 uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/local-recheck.log" -- \
   uv run --script "$TMS_RELEASE_CHECKS" write-manifest \
   --dist-dir "$TMS_LOCAL_ARTIFACTS/dist" \
@@ -356,33 +372,21 @@ Human review: pending
 # 8 Publish
 
 - Continue only after the Section 7 report has been reviewed and the human gives explicit confirmation.
-- Append every immediate pre-upload check and its complete output to `publish-recheck.log`:
+- Run one fail-closed command that appends every immediate pre-upload check and its complete output to `publish-recheck.log`:
 
 ```bash
-uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- git fetch origin master
-uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- git status --short --branch
-uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- git rev-parse HEAD
-uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- git rev-parse origin/master
-uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- \
-  zsh -lc 'test -z "$(git status --porcelain)" && test "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)"'
-uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- \
-  uv run --script "$TMS_RELEASE_CHECKS" verify-manifest \
+set -euxo pipefail
+UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --script "$TMS_RELEASE_CHECKS" pre-upload \
   --dist-dir "$TMS_LOCAL_ARTIFACTS/dist" \
-  --manifest "$TMS_LOCAL_ARTIFACTS/artifacts.sha256"
-uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- \
-  uv run --script "$TMS_RELEASE_CHECKS" artifacts \
-  --dist-dir "$TMS_LOCAL_ARTIFACTS/dist" \
+  --manifest "$TMS_LOCAL_ARTIFACTS/artifacts.sha256" \
   --expected-version "$TMS_RELEASE_VERSION" \
-  --repo-root .
-uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- \
-  zsh -lc 'UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine python -m twine check "$TMS_LOCAL_ARTIFACTS"/dist/*'
-uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- \
-  uv run --script "$TMS_RELEASE_CHECKS" publish-preflight \
-  --expected-version "$TMS_RELEASE_VERSION" \
+  --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" \
+  --repo-root . \
   --remote origin \
   --repository fzyzcjy/torch_memory_saver
 ```
 
+- The command fetches `origin/master`; requires a clean tree and `HEAD == origin/master`; verifies the approved manifest; reruns the complete artifact and Twine gates; and rejects existing PyPI, tag, or GitHub Release identities.
 - Require the verified manifest to equal the three hashes approved in the Section 7 report.
 - Upload only the files covered by that manifest.
 - Treat an existing PyPI version, remote `v<VERSION>` tag, or GitHub Release as a hard failure.
@@ -390,6 +394,7 @@ uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publi
 - Upload without `--skip-existing`; a collision is a hard failure:
 
 ```bash
+set -euxo pipefail
 UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine \
   python -m twine upload --non-interactive --repository pypi "$TMS_LOCAL_ARTIFACTS"/dist/*
 ```
@@ -398,6 +403,7 @@ UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine \
 - Create an annotated tag and prerelease only after PyPI confirms the version:
 
 ```bash
+set -euxo pipefail
 git tag -a "v$TMS_RELEASE_VERSION" -m "Release $TMS_RELEASE_VERSION" "$(git rev-parse HEAD)"
 git push origin "v$TMS_RELEASE_VERSION"
 gh release create "v$TMS_RELEASE_VERSION" \
@@ -411,16 +417,33 @@ gh release create "v$TMS_RELEASE_VERSION" \
 - Omit `--prerelease` for a stable release.
 - Never reuse or move a published version tag.
 
-# 9 Post-release verification
+# 9 Verify the published release from fresh containers
 
 ```bash
-curl -fsSL "https://pypi.org/pypi/torch-memory-saver/$TMS_RELEASE_VERSION/json"
-python -m pip install --pre "torch_memory_saver==$TMS_RELEASE_VERSION"
-gh release view "v$TMS_RELEASE_VERSION" --repo fzyzcjy/torch_memory_saver
+set -euxo pipefail
+rsync -a "$TMS_LOCAL_ARTIFACTS/artifacts.sha256" \
+  "tom-workstation:$TMS_REMOTE_ARTIFACTS/artifacts.sha256"
+ssh tom-workstation "set -euxo pipefail
+cd '$TMS_REMOTE_ROOT'
+TMS_PROXY_URL=http://127.0.0.1:7890 \
+  .claude/skills/tms-publish-release/scripts/verify_published_release.sh \
+  '$TMS_RELEASE_VERSION' \
+  '$TMS_REMOTE_ARTIFACTS/artifacts.sha256'" \
+  2>&1 | tee "$TMS_LOCAL_ARTIFACTS/verify-published-release.log"
 ```
 
-- Verify PyPI lists both wheels and the sdist with the recorded hashes.
-- Run an install smoke test in a fresh CUDA 12 environment; use `--pre` for beta or RC versions.
+- Run this chapter only after PyPI, the Git tag, and the GitHub Release exist.
+- Copy the approved `artifacts.sha256` to `$TMS_REMOTE_ARTIFACTS` before invoking the script.
+- Keep Chapter 9 implemented as auditable shell; do not move it into a Python orchestration command.
+- Require PyPI to contain exactly the two wheels and sdist recorded by the approved manifest, with matching SHA-256 digests.
+- Require the GitHub Release for `v$TMS_RELEASE_VERSION` to exist.
+- Require prerelease versions to map to a GitHub prerelease and stable versions to map to a non-prerelease.
+- Start one fresh `--rm` container for each CUDA major.
+- Before installation, require Python to report that `torch_memory_saver` is absent.
+- Install the exact published version from PyPI, never from the local `dist/` directory.
+- Require the installed package to resolve from `site-packages`, PyTorch to report the matching CUDA major, and the GPU to be the 4090D.
+- Run the complete runtime pytest suite with the exact structured skip gate in both containers.
+- Require local `verify-published-release.log` to contain two passing pytest summaries and terminal `RESULT: returncode=0`.
 - Report any partial release state explicitly.
 - Never delete a published PyPI version to make a retry look clean.
 - Increment the prerelease number for a retry.

--- a/.claude/skills/tms-publish-release/SKILL.md
+++ b/.claude/skills/tms-publish-release/SKILL.md
@@ -211,10 +211,10 @@ Source mount: release root at /workspace, read-only
 Install root: final wheel into site-packages or dist-packages
 Test root: /validation, outside the source checkout
 x86_64 test suite: full single-GPU runtime pytest
-ARM64 test suite: runtime pytest with the exact Lupine deselections below
-Lupine deselection 1: test/test_examples.py::test_cpu_backup_preload_backend_from_env
-Lupine deselection 2: test/test_examples.py::test_disk_backup[preload]
-Lupine deselection 3: test/test_examples.py::test_disk_backup[torch]
+ARM64 test suite: full runtime pytest with in-test Lupine skip markers
+Lupine signal: TMS_TEST_LUPINE=1 in ARM64 validation containers only
+Lupine skip 1: test_cpu_backup_preload_backend_from_env
+Lupine skip 2: test_disk_backup, including both hook-mode parameters
 CUDA major: matches the matrix cell
 CUDA availability: torch.cuda.is_available() is true
 GPU identity: NVIDIA GeForce RTX 4090 D
@@ -224,9 +224,10 @@ Binary architecture: every loaded ELF machine matches the matrix cell
 Inventory gate: every repository test_*.py classified as runtime or build tooling
 Build-tool UT: build phase only
 Success: zero failures in all four cells
-Allowed skips: single-GPU multi-device cases and XPU-only cases
+Allowed skips: documented Lupine host-memory cases, single-GPU multi-device cases, XPU-only cases
 Skip review: inspect every reason
-Additional skip or deselection: forbidden
+CLI deselection: forbidden
+Additional skip: forbidden
 Evidence: image identity, environment, commands, installed paths, binaries, pytest output
 Cleanup: named clients, servers, containers, and private networks removed on success or failure
 ```
@@ -245,6 +246,7 @@ Preinstalled: ARM Python, PyTorch, CUDA user-space libraries, CUDA/NVML shims
 Added test dependencies: pinned binary NumPy, pytest, nvidia-ml-py wheels
 Execution: real ARM64 Python, PyTorch, and TMS wheel under QEMU
 GPU path: CUDA driver and NVML calls forwarded to the physical 4090D
+Test signal: TMS_TEST_LUPINE=1
 Qualification: ARM user-space GPU behavior through Lupine
 Not qualified: ARM NVIDIA kernel driver or native ARM PCIe path
 Disk-backup boundary: Lupine protects pinned host mirrors read-only, so kernel pread returns EFAULT

--- a/.claude/skills/tms-publish-release/SKILL.md
+++ b/.claude/skills/tms-publish-release/SKILL.md
@@ -21,44 +21,67 @@ description: Use when preparing, building, validating, publishing, or verifying 
 - Treat PyPI upload and Git tag push as irreversible.
 - Complete the Section 8 confirmation gate before either action.
 
-# 2 Preflight
-
-## 2.1 Repository and version
+# 2 Prepare isolated paths
 
 ```bash
-git fetch origin master
-git status --short --branch
-git rev-parse HEAD
-git rev-parse origin/master
-git diff --stat origin/master...HEAD
+export TMS_RELEASE_VERSION=<VERSION>
+export TMS_RELEASE_SHA="$(git rev-parse --short=12 HEAD)"
+export TMS_RELEASE_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+export TMS_REMOTE_ROOT="/home/tom/workspace/torch_memory_saver_release_${TMS_RELEASE_VERSION}_${TMS_RELEASE_SHA}_${TMS_RELEASE_RUN_ID}"
+export TMS_REMOTE_ARTIFACTS="${TMS_REMOTE_ROOT}_artifacts"
+export TMS_LOCAL_ARTIFACTS="/Users/tom/domains/human/others/artifacts/torch_memory_saver/${TMS_RELEASE_VERSION}-${TMS_RELEASE_SHA}-${TMS_RELEASE_RUN_ID}-release"
+export TMS_RELEASE_CHECKS="$PWD/.claude/skills/tms-publish-release/scripts/release_checks.py"
+mkdir "$TMS_LOCAL_ARTIFACTS"
+```
+
+- Never reuse a local or remote source or artifact directory, even for the same version and commit.
+- Keep every build, validation, environment, and recheck log under the unique artifact directories.
+
+# 3 Preflight
+
+## 3.1 Repository and version
+
+- Append every command, complete output, and exit result to `release-preflight.log`:
+
+```bash
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- git fetch origin master
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- git status --short --branch
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- git rev-parse HEAD
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- git rev-parse origin/master
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- git diff --stat origin/master...HEAD
 ```
 
 - Stop if the tree is dirty, `HEAD` differs from `origin/master`, or the release commit is detached.
 - Read and validate the version without importing `setup.py`:
 
 ```bash
-uv run --script .claude/skills/tms-publish-release/scripts/release_checks.py version \
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
+  uv run --script "$TMS_RELEASE_CHECKS" version \
   --setup-py setup.py \
-  --expected-version <VERSION>
+  --expected-version "$TMS_RELEASE_VERSION"
 ```
 
 - Confirm the target version does not already exist on PyPI:
 
 ```bash
-uv run --script .claude/skills/tms-publish-release/scripts/release_checks.py pypi \
-  --expected-version <VERSION>
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
+  uv run --script "$TMS_RELEASE_CHECKS" pypi \
+  --expected-version "$TMS_RELEASE_VERSION"
 ```
 
 - Review every change since the previous release commit.
 - Use `c29087a58db9d120b3e69623714c5dd043029d77` as the historical source baseline for the first tagged release after `0.0.9.post1`.
 - Use the previous release tag after the first tagged release.
 
-## 2.2 Host and credential checks
+## 3.2 Host and credential checks
 
 ```bash
-ssh tom-workstation 'curl --retry 5 --retry-delay 1 --retry-all-errors -x http://127.0.0.1:7890 -I --max-time 20 https://registry-1.docker.io/v2/'
-ssh tom-workstation 'test -x /home/tom/.local/bin/uv; nvidia-smi --query-gpu=index,name,driver_version,memory.total,memory.used,utilization.gpu --format=csv,noheader; docker version; df -h / /home/tom'
-/usr/bin/stat -f '%N mode=%Lp size=%z' "$HOME/.pypirc"
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
+  ssh tom-workstation 'curl --retry 5 --retry-delay 1 --retry-all-errors -x http://127.0.0.1:7890 -I --max-time 20 https://registry-1.docker.io/v2/'
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
+  ssh tom-workstation 'test -x /home/tom/.local/bin/uv; nvidia-smi --query-gpu=index,name,driver_version,memory.total,memory.used,utilization.gpu --format=csv,noheader; docker version; df -h / /home/tom'
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
+  /usr/bin/stat -f '%N mode=%Lp size=%z' "$HOME/.pypirc"
 ```
 
 - Expect HTTP `401` from the Docker Hub registry probe; it proves official registry reachability.
@@ -68,13 +91,14 @@ ssh tom-workstation 'test -x /home/tom/.local/bin/uv; nvidia-smi --query-gpu=ind
 - Never copy it to `tom-workstation`.
 - Never mount it into a long-lived container.
 
-## 2.3 ARM64 emulation on the x86_64 host
+## 3.3 ARM64 emulation on the x86_64 host
 
 - The official `manylinuxaarch64-builder` images are Linux ARM64 images, not x86 cross-compiler images.
 - Check for an existing ARM64 binfmt handler:
 
 ```bash
-ssh tom-workstation 'test -r /proc/sys/fs/binfmt_misc/qemu-aarch64 && cat /proc/sys/fs/binfmt_misc/qemu-aarch64'
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
+  ssh tom-workstation 'test -r /proc/sys/fs/binfmt_misc/qemu-aarch64 && cat /proc/sys/fs/binfmt_misc/qemu-aarch64'
 ```
 
 - If it is missing, stop for approval before installing QEMU binfmt.
@@ -83,7 +107,8 @@ ssh tom-workstation 'test -r /proc/sys/fs/binfmt_misc/qemu-aarch64 && cat /proc/
 - After approval, install only ARM64 and verify it with an ARM64 Alpine container:
 
 ```bash
-ssh tom-workstation 'docker run --privileged --rm tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install arm64
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
+  ssh tom-workstation 'docker run --privileged --rm tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install arm64
 cat /proc/sys/fs/binfmt_misc/qemu-aarch64
 docker run --rm --platform linux/arm64 alpine:3.22 uname -m'
 ```
@@ -91,29 +116,25 @@ docker run --rm --platform linux/arm64 alpine:3.22 uname -m'
 - Require the smoke test to print `aarch64`.
 - Treat binfmt as boot-scoped unless the host has an explicit persistent registration. Recheck this section after every workstation reboot.
 
-## 2.4 Release script roles
+## 3.4 Release script roles
 
 | Script | Responsibility | Mutates release state |
 | --- | --- | --- |
-| `.claude/skills/tms-publish-release/scripts/release_checks.py` | `version`, `pypi`, `sdist`, `artifacts`, and `publish-preflight` gates | No |
-| `.claude/skills/tms-publish-release/scripts/gpu_validation.py` | Four-cell fresh-container GPU runtime harness | Creates only temporary validation resources |
+| `.claude/skills/tms-publish-release/scripts/release_checks.py` | Version, namespace, artifact, manifest, publish-preflight, and append-only command-log gates | No |
+| `.claude/skills/tms-publish-release/scripts/gpu_validation.py` | Four-cell fresh-container GPU runtime harness with exact skip enforcement | Creates only temporary validation resources |
+| `.claude/skills/tms-publish-release/scripts/pytest_skip_gate.py` | Exact pytest skipped-node and reason validator loaded by the harness | No |
 
 - Keep upload, tag creation, and GitHub Release creation outside both scripts.
 - Use `sdist` only for focused diagnostics.
 - Use `artifacts` for the canonical release workflow after all three distributions exist.
 
-# 3 Prepare isolated paths
+## 3.5 Create and synchronize the remote source tree
 
 ```bash
-export TMS_RELEASE_VERSION=<VERSION>
-export TMS_RELEASE_SHA="$(git rev-parse --short=12 HEAD)"
-export TMS_RELEASE_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
-export TMS_REMOTE_ROOT="/home/tom/workspace/torch_memory_saver_release_${TMS_RELEASE_VERSION}_${TMS_RELEASE_SHA}_${TMS_RELEASE_RUN_ID}"
-export TMS_REMOTE_ARTIFACTS="${TMS_REMOTE_ROOT}_artifacts"
-export TMS_LOCAL_ARTIFACTS="/Users/tom/domains/human/others/artifacts/torch_memory_saver/${TMS_RELEASE_VERSION}-${TMS_RELEASE_SHA}-${TMS_RELEASE_RUN_ID}-release"
-mkdir "$TMS_LOCAL_ARTIFACTS"
-ssh tom-workstation "test ! -e '$TMS_REMOTE_ROOT' && test ! -e '$TMS_REMOTE_ARTIFACTS' && mkdir '$TMS_REMOTE_ROOT' '$TMS_REMOTE_ARTIFACTS'"
-rsync -a \
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
+  ssh tom-workstation "test ! -e '$TMS_REMOTE_ROOT' && test ! -e '$TMS_REMOTE_ARTIFACTS' && mkdir '$TMS_REMOTE_ROOT' '$TMS_REMOTE_ARTIFACTS'"
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
+  rsync -a \
   --exclude .git \
   --exclude build \
   --exclude dist \
@@ -121,14 +142,14 @@ rsync -a \
   --exclude .pytest_cache \
   --exclude '*.so' \
   ./ "tom-workstation:$TMS_REMOTE_ROOT/"
-shasum -a 256 setup.py
-ssh tom-workstation "sha256sum '$TMS_REMOTE_ROOT/setup.py'"
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- shasum -a 256 setup.py
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/release-preflight.log" -- \
+  ssh tom-workstation "sha256sum '$TMS_REMOTE_ROOT/setup.py'"
 ```
 
 - Do not use `rsync --delete`.
-- **Isolation**: Never reuse a remote source or artifact directory, even for the same version and commit.
-    - The fail-if-present `mkdir` and run ID make every rehearsal independent.
-- **Logs**: Put every build, validation, and environment log in the unique remote artifact directory.
+- Require the local and remote `setup.py` hashes to match.
+- The fail-if-present remote `mkdir` makes every rehearsal independent.
 
 # 4 Build release distributions
 
@@ -225,9 +246,10 @@ Inventory gate: every repository test_*.py classified as runtime or build toolin
 Build-tool UT: build phase only
 Success: zero failures in all four cells
 Allowed skips: documented Lupine host-memory cases, single-GPU multi-device cases, XPU-only cases
-Skip review: inspect every reason
+Skip gate: exact node ID and normalized reason map passed through TMS_EXPECTED_PYTEST_SKIPS
+Skip result: SKIP_GATE_ACTUAL and SKIP_GATE_RESULT recorded in the cell log
 CLI deselection: forbidden
-Additional skip: forbidden
+Missing, additional, duplicated, or reason-changed skip: cell failure
 Evidence: image identity, environment, commands, installed paths, binaries, pytest output
 Command log: EXEC line, complete stdout/stderr, terminal RESULT line
 Container shell trace: set -euxo pipefail records each in-container command
@@ -255,6 +277,7 @@ Disk-backup boundary: Lupine protects pinned host mirrors read-only, so kernel p
 RSS boundary: Lupine first-transfer buffers invalidate the preload RSS delta assertion
 Product-code workaround: forbidden; keep both behaviors covered by the direct x86_64 cells
 Derived client image: forbidden
+Server evidence: complete Lupine server output captured with docker logs before cleanup
 ```
 
 ## 5.2 Run the harness
@@ -271,19 +294,27 @@ ssh tom-workstation "HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0
 # 6 Pull and recheck artifacts locally
 
 ```bash
-rsync -a "tom-workstation:$TMS_REMOTE_ARTIFACTS/" "$TMS_LOCAL_ARTIFACTS/"
-rsync -a "tom-workstation:$TMS_REMOTE_ROOT/dist/" "$TMS_LOCAL_ARTIFACTS/dist/"
-uv run --script .claude/skills/tms-publish-release/scripts/release_checks.py artifacts \
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/local-recheck.log" -- \
+  rsync -a "tom-workstation:$TMS_REMOTE_ARTIFACTS/" "$TMS_LOCAL_ARTIFACTS/"
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/local-recheck.log" -- \
+  rsync -a "tom-workstation:$TMS_REMOTE_ROOT/dist/" "$TMS_LOCAL_ARTIFACTS/dist/"
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/local-recheck.log" -- \
+  uv run --script "$TMS_RELEASE_CHECKS" artifacts \
   --dist-dir "$TMS_LOCAL_ARTIFACTS/dist" \
   --expected-version "$TMS_RELEASE_VERSION" \
   --repo-root .
-shasum -a 256 "$TMS_LOCAL_ARTIFACTS"/dist/*
-UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine \
-  python -m twine check "$TMS_LOCAL_ARTIFACTS"/dist/*
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/local-recheck.log" -- \
+  zsh -lc 'UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine python -m twine check "$TMS_LOCAL_ARTIFACTS"/dist/*'
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/local-recheck.log" -- \
+  uv run --script "$TMS_RELEASE_CHECKS" write-manifest \
+  --dist-dir "$TMS_LOCAL_ARTIFACTS/dist" \
+  --output "$TMS_LOCAL_ARTIFACTS/artifacts.sha256"
 ```
 
 - Do not upload directly from the remote build directory.
 - Keep all three distribution files and full logs at the permanent local artifact path.
+- Treat `artifacts.sha256` as the immutable human-review boundary.
+- Never overwrite or regenerate the manifest after human review; start a new run instead.
 
 # 7 Write the release evidence report
 
@@ -298,7 +329,9 @@ Source: full release SHA, branch, clean-tree evidence
 Version: canonical version and collision-check results
 Host: workstation, GPU, driver, kernel, Docker, binfmt
 Artifacts: filename, size, SHA-256, metadata result, twine result, file link
+Preflight evidence: release-preflight.log
 Build evidence: x86_64 log, aarch64 log, sdist log, artifact-validator log
+Local evidence: local-recheck.log and artifacts.sha256
 GPU matrix row: architecture, CUDA major, image digest, PyTorch/CUDA/GPU identity
 GPU matrix result: pytest summary, every skip reason, terminal RESULT, log link
 Lupine boundary: TMS_TEST_LUPINE signal, exact skipped tests, qualification limit
@@ -313,6 +346,8 @@ Human review: pending
     - `x86_64-cuda13-gpu.log`.
     - `aarch64-cuda12-gpu.log`.
     - `aarch64-cuda13-gpu.log`.
+- Link `release-preflight.log`, `local-recheck.log`, and `artifacts.sha256`.
+- Transcribe the three manifest lines into the artifact table without changing their hashes.
 - Require every harness-invoked external command to have an `EXEC` line and a terminal `RESULT` line.
 - Require every GPU row to link the exact log containing image identity, pytest output, skip reasons, and cleanup.
 - Stop after writing the report.
@@ -321,16 +356,35 @@ Human review: pending
 # 8 Publish
 
 - Continue only after the Section 7 report has been reviewed and the human gives explicit confirmation.
-- Re-fetch `origin/master` and repeat the clean-tree and exact-SHA checks immediately before upload.
-- Recheck every immutable release namespace:
+- Append every immediate pre-upload check and its complete output to `publish-recheck.log`:
 
 ```bash
-uv run --script .claude/skills/tms-publish-release/scripts/release_checks.py publish-preflight \
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- git fetch origin master
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- git status --short --branch
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- git rev-parse HEAD
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- git rev-parse origin/master
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- \
+  zsh -lc 'test -z "$(git status --porcelain)" && test "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)"'
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- \
+  uv run --script "$TMS_RELEASE_CHECKS" verify-manifest \
+  --dist-dir "$TMS_LOCAL_ARTIFACTS/dist" \
+  --manifest "$TMS_LOCAL_ARTIFACTS/artifacts.sha256"
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- \
+  uv run --script "$TMS_RELEASE_CHECKS" artifacts \
+  --dist-dir "$TMS_LOCAL_ARTIFACTS/dist" \
+  --expected-version "$TMS_RELEASE_VERSION" \
+  --repo-root .
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- \
+  zsh -lc 'UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine python -m twine check "$TMS_LOCAL_ARTIFACTS"/dist/*'
+uv run --script "$TMS_RELEASE_CHECKS" run --log-path "$TMS_LOCAL_ARTIFACTS/publish-recheck.log" -- \
+  uv run --script "$TMS_RELEASE_CHECKS" publish-preflight \
   --expected-version "$TMS_RELEASE_VERSION" \
   --remote origin \
   --repository fzyzcjy/torch_memory_saver
 ```
 
+- Require the verified manifest to equal the three hashes approved in the Section 7 report.
+- Upload only the files covered by that manifest.
 - Treat an existing PyPI version, remote `v<VERSION>` tag, or GitHub Release as a hard failure.
 - Treat network and authentication errors as hard failures.
 - Upload without `--skip-existing`; a collision is a hard failure:
@@ -386,5 +440,8 @@ gh release view "v$TMS_RELEASE_VERSION" --repo fzyzcjy/torch_memory_saver
 | `make clean` reports `Permission denied` under `dist/` | An older build left root-owned bind-mount output | Remove only the dedicated rehearsal output through a root Docker container, then use the current scripts that normalize ownership |
 | Wheel test imports `/workspace/torch_memory_saver` | Pytest ran against the source tree | Copy only `test/` to `/validation` and rerun against the installed wheel |
 | CUDA 13 preload tests report `libcudart.so.13` missing | The runtime image installs CUDART under Python `site-packages/nvidia/cu13/lib` without registering it in `ldconfig` | Discover the matching CUDART path before pytest and export it through `LD_LIBRARY_PATH`; do not skip preload tests |
+| `SKIP_GATE_RESULT=fail` | A skip is missing, additional, duplicated, or has a changed reason | Inspect `SKIP_GATE_ACTUAL`; update code or the reviewed matrix contract instead of silently accepting it |
+| Cleanup raises after a passing cell | Docker cleanup timed out or could not start | Inspect the complete cell log; the harness attempted every cleanup command and preserved any earlier validation error |
+| Manifest verification fails | An artifact changed or the file set differs after human review | Stop and start a new build and review run; never regenerate the approved manifest |
 | `dist/` has extra wheels | Stale or partial build output | Stop and start a new run directory; never repair or reuse a release tree |
 | PyPI upload reports an existing filename | Version or artifact was already published | Stop; never use `--skip-existing` or overwrite a release |

--- a/.claude/skills/tms-publish-release/SKILL.md
+++ b/.claude/skills/tms-publish-release/SKILL.md
@@ -19,7 +19,7 @@ description: Use when preparing, building, validating, publishing, or verifying 
 - Publish from the local controller.
 - Never persist PyPI credentials on the GPU host.
 - Treat PyPI upload and Git tag push as irreversible.
-- Complete the Section 7 confirmation gate before either action.
+- Complete the Section 8 confirmation gate before either action.
 
 # 2 Preflight
 
@@ -229,6 +229,8 @@ Skip review: inspect every reason
 CLI deselection: forbidden
 Additional skip: forbidden
 Evidence: image identity, environment, commands, installed paths, binaries, pytest output
+Command log: EXEC line, complete stdout/stderr, terminal RESULT line
+Container shell trace: set -euxo pipefail records each in-container command
 Cleanup: named clients, servers, containers, and private networks removed on success or failure
 ```
 
@@ -283,15 +285,42 @@ UV_CACHE_DIR="$TMS_LOCAL_ARTIFACTS/uv-cache" uv run --no-project --with twine \
 - Do not upload directly from the remote build directory.
 - Keep all three distribution files and full logs at the permanent local artifact path.
 
-# 7 Publish
+# 7 Write the release evidence report
 
-- Present the release evidence to the human:
-    - Exact version.
-    - Full release SHA.
-    - Three filenames and SHA-256 hashes.
-    - Four fresh-container GPU results.
-    - Explicit Lupine qualification boundary.
-- Continue only after explicit confirmation.
+- Write one Markdown report in the matching local agent-context project `agent-drafts/` directory.
+- Use the exact version and run ID in the filename.
+- Link every raw artifact and log with its final absolute local path.
+- Do not copy raw logs into the report.
+- Set `Human review: pending` until the report has been inspected.
+
+```text
+Source: full release SHA, branch, clean-tree evidence
+Version: canonical version and collision-check results
+Host: workstation, GPU, driver, kernel, Docker, binfmt
+Artifacts: filename, size, SHA-256, metadata result, twine result, file link
+Build evidence: x86_64 log, aarch64 log, sdist log, artifact-validator log
+GPU matrix row: architecture, CUDA major, image digest, PyTorch/CUDA/GPU identity
+GPU matrix result: pytest summary, every skip reason, terminal RESULT, log link
+Lupine boundary: TMS_TEST_LUPINE signal, exact skipped tests, qualification limit
+Cleanup: validation containers, server, and network removal evidence
+Safety: PyPI upload, release tag, and GitHub Release not performed
+Human review: pending
+```
+
+- Link all five harness logs:
+    - `preflight.log`.
+    - `x86_64-cuda12-gpu.log`.
+    - `x86_64-cuda13-gpu.log`.
+    - `aarch64-cuda12-gpu.log`.
+    - `aarch64-cuda13-gpu.log`.
+- Require every harness-invoked external command to have an `EXEC` line and a terminal `RESULT` line.
+- Require every GPU row to link the exact log containing image identity, pytest output, skip reasons, and cleanup.
+- Stop after writing the report.
+- Give the human the report link and wait for explicit publish approval.
+
+# 8 Publish
+
+- Continue only after the Section 7 report has been reviewed and the human gives explicit confirmation.
 - Re-fetch `origin/master` and repeat the clean-tree and exact-SHA checks immediately before upload.
 - Recheck every immutable release namespace:
 
@@ -328,7 +357,7 @@ gh release create "v$TMS_RELEASE_VERSION" \
 - Omit `--prerelease` for a stable release.
 - Never reuse or move a published version tag.
 
-# 8 Post-release verification
+# 9 Post-release verification
 
 ```bash
 curl -fsSL "https://pypi.org/pypi/torch-memory-saver/$TMS_RELEASE_VERSION/json"
@@ -342,7 +371,7 @@ gh release view "v$TMS_RELEASE_VERSION" --repo fzyzcjy/torch_memory_saver
 - Never delete a published PyPI version to make a retry look clean.
 - Increment the prerelease number for a retry.
 
-# 9 Reliability
+# 10 Reliability
 
 | Symptom | Cause | Action |
 | --- | --- | --- |

--- a/.claude/skills/tms-publish-release/agents/openai.yaml
+++ b/.claude/skills/tms-publish-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TMS Publish Release"
+  short_description: "Build, validate, and publish TMS releases"
+  default_prompt: "Use $tms-publish-release to prepare and publish a torch_memory_saver release."

--- a/.claude/skills/tms-publish-release/scripts/gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/gpu_validation.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["click", "typer"]
+# ///
+
+from __future__ import annotations
+
+import hashlib
+import platform
+import shlex
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated
+from urllib.parse import urlsplit, urlunsplit
+
+import click
+import typer
+
+app = typer.Typer(add_completion=False)
+
+_PROXY_URL = "http://127.0.0.1:7890"
+_COMMAND_TIMEOUT_SECONDS = 7200
+_RUNTIME_TEST_MODULES = (
+    "test_configure_subprocess.py",
+    "test_examples.py",
+    "test_utils.py",
+)
+_BUILD_TOOL_TEST_MODULES = ("test_merge_cuda_wheels.py",)
+_X86_VALIDATION_SCRIPT = r"""
+set -euxo pipefail
+python --version
+python - <<'PY'
+import os
+import torch
+
+cuda = torch.version.cuda
+name = torch.cuda.get_device_name(0)
+print(torch.__version__, cuda, torch.cuda.is_available(), name)
+assert cuda is not None and cuda.split(".", 1)[0] == os.environ["TMS_CUDA_MAJOR"]
+assert torch.cuda.is_available()
+assert "4090 D" in name or "4090D" in name
+PY
+CUDA_RUNTIME_LIB="$(python -c 'from pathlib import Path; import os, site; major=os.environ["TMS_CUDA_MAJOR"]; matches=[path for root in site.getsitepackages() for path in (Path(root) / "nvidia").glob(f"**/libcudart.so.{major}")]; assert matches, matches; print(":".join(sorted({str(path.parent) for path in matches})))')"
+export LD_LIBRARY_PATH="${CUDA_RUNTIME_LIB}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+echo "CUDA_RUNTIME_LIB=${CUDA_RUNTIME_LIB}"
+python -m pip install --no-cache-dir pytest==8.3.5 nvidia-ml-py==12.570.86
+python -m pip install --no-deps "/workspace/dist/torch_memory_saver-${TMS_RELEASE_VERSION}-cp39-abi3-manylinux2014_x86_64.whl"
+mkdir -p /validation/test
+cp -a /workspace/test/examples /validation/test/examples
+cp /workspace/test/test_configure_subprocess.py /workspace/test/test_examples.py /workspace/test/test_utils.py /validation/test/
+cd /validation
+python -c 'from pathlib import Path; import torch_memory_saver; path=Path(torch_memory_saver.__file__); print(path); assert "site-packages" in path.parts'
+CUDA_VISIBLE_DEVICES=0 timeout --signal=TERM --kill-after=30s 3600s python -m pytest test -vv -ra
+""".strip()
+_ARM_VALIDATION_SCRIPT = r"""
+set -euxo pipefail
+python3 --version
+uname -m
+python3 -m pip install --break-system-packages --only-binary=:all: --no-cache-dir pytest==8.3.5 numpy==2.2.3 nvidia-ml-py==12.570.86
+python3 -m pip install --break-system-packages --no-deps "/workspace/dist/torch_memory_saver-${TMS_RELEASE_VERSION}-cp39-abi3-manylinux2014_aarch64.whl"
+mkdir -p /validation/test
+cp -a /workspace/test/examples /validation/test/examples
+cp /workspace/test/test_configure_subprocess.py /workspace/test/test_examples.py /workspace/test/test_utils.py /validation/test/
+cd /validation
+python3 - <<'PY'
+from pathlib import Path
+import os
+import platform
+import torch
+import torch_memory_saver
+
+cuda = torch.version.cuda
+name = torch.cuda.get_device_name(0)
+package_path = Path(torch_memory_saver.__file__)
+print(platform.machine(), torch.__version__, cuda, torch.cuda.is_available(), name)
+print(package_path)
+assert platform.machine() == "aarch64"
+assert cuda is not None and cuda.split(".", 1)[0] == os.environ["TMS_CUDA_MAJOR"]
+assert torch.cuda.is_available()
+assert "4090 D" in name or "4090D" in name
+assert any(part in {"site-packages", "dist-packages"} for part in package_path.parts)
+PY
+python3 - <<'PY'
+from pathlib import Path
+import platform
+import torch
+import torch_memory_saver
+
+paths = [Path(torch._C.__file__), *Path(torch_memory_saver.__file__).parent.parent.glob("torch_memory_saver_hook_mode_*.abi3.so")]
+assert paths
+for path in paths:
+    binary = path.read_bytes()[:20]
+    assert binary[:4] == b"\x7fELF", path
+    byte_order = "little" if binary[5] == 1 else "big"
+    assert int.from_bytes(binary[18:20], byteorder=byte_order) == 183, path
+    print(platform.machine(), path)
+PY
+CUDA_RUNTIME_LIB="$(python3 -c 'from pathlib import Path; import os, site; major=os.environ["TMS_CUDA_MAJOR"]; matches=[path for root in site.getsitepackages() for path in (Path(root) / "nvidia").glob(f"**/libcudart.so.{major}")]; assert matches, matches; print(":".join(sorted({str(path.parent) for path in matches})))')"
+export LD_LIBRARY_PATH="${CUDA_RUNTIME_LIB}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+echo "CUDA_RUNTIME_LIB=${CUDA_RUNTIME_LIB}"
+CUDA_VISIBLE_DEVICES=0 timeout --signal=TERM --kill-after=30s 3600s python3 -m pytest test -vv -ra \
+  --deselect 'test/test_examples.py::test_cpu_backup_preload_backend_from_env' \
+  --deselect 'test/test_examples.py::test_disk_backup[preload]' \
+  --deselect 'test/test_examples.py::test_disk_backup[torch]'
+""".strip()
+
+
+@dataclass(frozen=True)
+class GpuValidationConfig:
+    release_root: Path
+    run_dir: Path
+    expected_version: str
+    proxy_url: str
+
+
+@dataclass(frozen=True)
+class GpuValidationCase:
+    name: str
+    image: str
+    architecture: str
+    cuda_major: str
+    server_image: str | None = None
+
+
+_GPU_VALIDATION_CASES: tuple[GpuValidationCase, ...] = (
+    GpuValidationCase(
+        name="x86_64-cuda12-gpu",
+        image="docker.io/pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime",
+        architecture="x86_64",
+        cuda_major="12",
+    ),
+    GpuValidationCase(
+        name="x86_64-cuda13-gpu",
+        image="docker.io/pytorch/pytorch:2.9.1-cuda13.0-cudnn9-runtime",
+        architecture="x86_64",
+        cuda_major="13",
+    ),
+    GpuValidationCase(
+        name="aarch64-cuda12-gpu",
+        image="ghcr.io/lupinemachines/lupine-pytorch-worker@sha256:f152fbcb3e2eda5661abafdfb4f3024afe9b775eb702015b5df0527ca0b7f556",
+        architecture="aarch64",
+        cuda_major="12",
+        server_image="ghcr.io/lupinemachines/lupine-server@sha256:e6b1103392165e929ca7f4f910eeec9f0b0f7155c5ff65b7402ca083c6bf9d53",
+    ),
+    GpuValidationCase(
+        name="aarch64-cuda13-gpu",
+        image="ghcr.io/lupinemachines/lupine-pytorch-worker@sha256:a154530bfeed825e8c915be1b6129965f293dbf29ce4764441014dccf9c6c08a",
+        architecture="aarch64",
+        cuda_major="13",
+        server_image="ghcr.io/lupinemachines/lupine-server@sha256:f1d805e14e0b2da5d5912adeed72f3e1c7d0458082c3cbaf3ba9bb2346b869cd",
+    ),
+)
+
+
+@app.command()
+def main(
+    release_root: Annotated[
+        Path,
+        typer.Option(
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+    artifact_root: Annotated[
+        Path,
+        typer.Option(
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            writable=True,
+            resolve_path=True,
+        ),
+    ],
+    expected_version: Annotated[str, typer.Option()],
+    proxy_url: Annotated[str, typer.Option()] = _PROXY_URL,
+) -> None:
+    config = _build_config(
+        release_root=release_root,
+        artifact_root=artifact_root,
+        expected_version=expected_version,
+        proxy_url=proxy_url,
+    )
+    try:
+        run_gpu_validation(config=config)
+    except (
+        RuntimeError,
+        ValueError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as error:
+        raise click.ClickException(f"{error}; logs: {config.run_dir}") from error
+    typer.echo(f"Validated release GPU matrix in fresh containers: {config.run_dir}")
+
+
+def run_gpu_validation(*, config: GpuValidationConfig) -> None:
+    if platform.machine() != "x86_64":
+        raise RuntimeError(
+            f"GPU validation requires the x86_64 tom-workstation host, found {platform.machine()}"
+        )
+
+    _require_release_wheels(config=config)
+    _require_runtime_test_contract(release_root=config.release_root)
+    preflight_log = config.run_dir / "preflight.log"
+    _exec_command(command=["docker", "info"], log_path=preflight_log)
+    _exec_command(
+        command=[
+            "nvidia-smi",
+            "--query-gpu=index,name,driver_version,memory.total,memory.used,utilization.gpu",
+            "--format=csv,noheader",
+        ],
+        log_path=preflight_log,
+    )
+
+    for case in _GPU_VALIDATION_CASES:
+        if case.architecture == "aarch64":
+            _run_lupine_case(config=config, case=case)
+        else:
+            _run_x86_case(config=config, case=case)
+
+
+def _build_config(
+    *,
+    release_root: Path,
+    artifact_root: Path,
+    expected_version: str,
+    proxy_url: str,
+) -> GpuValidationConfig:
+    release_root = release_root.resolve()
+    artifact_root = artifact_root.resolve()
+    run_dir = artifact_root / datetime.now(tz=timezone.utc).strftime(
+        "gpu-validation-%Y%m%d-%H%M%S-%fZ"
+    )
+    run_dir.mkdir()
+
+    return GpuValidationConfig(
+        release_root=release_root,
+        run_dir=run_dir,
+        expected_version=expected_version,
+        proxy_url=proxy_url,
+    )
+
+
+def _require_release_wheels(*, config: GpuValidationConfig) -> None:
+    expected_wheels = [
+        config.release_root
+        / "dist"
+        / f"torch_memory_saver-{config.expected_version}-cp39-abi3-manylinux2014_{architecture}.whl"
+        for architecture in ("x86_64", "aarch64")
+    ]
+    if missing_wheels := [path for path in expected_wheels if not path.is_file()]:
+        raise ValueError(f"Missing release wheels: {missing_wheels}")
+
+
+def _require_runtime_test_contract(*, release_root: Path) -> None:
+    test_dir = release_root / "test"
+    actual_modules = {path.name for path in test_dir.glob("test_*.py")}
+    expected_modules = set(_RUNTIME_TEST_MODULES) | set(_BUILD_TOOL_TEST_MODULES)
+    if actual_modules != expected_modules:
+        missing = sorted(expected_modules - actual_modules)
+        unclassified = sorted(actual_modules - expected_modules)
+        raise ValueError(
+            f"Release test classification mismatch: missing={missing}, unclassified={unclassified}"
+        )
+    if not (test_dir / "examples").is_dir():
+        raise ValueError(f"Missing runtime examples: {test_dir / 'examples'}")
+
+
+def _run_x86_case(*, config: GpuValidationConfig, case: GpuValidationCase) -> None:
+    log_path = config.run_dir / f"{case.name}.log"
+    container_name = f"{_resource_prefix(config=config, case=case)}-validation"
+    identity_logged = False
+    try:
+        _exec_command(
+            command=[
+                "docker",
+                "run",
+                "--rm",
+                "--pull",
+                "missing",
+                "--name",
+                container_name,
+                "--gpus",
+                "device=0",
+                "--network",
+                "host",
+                *_environment_args(
+                    config=config,
+                    case=case,
+                    proxy_url=config.proxy_url,
+                ),
+                "-v",
+                f"{config.release_root}:/workspace:ro",
+                case.image,
+                "bash",
+                "-lc",
+                _X86_VALIDATION_SCRIPT,
+            ],
+            log_path=log_path,
+        )
+        _inspect_image(image=case.image, log_path=log_path)
+        identity_logged = True
+    finally:
+        if not identity_logged:
+            _inspect_image(image=case.image, log_path=log_path, check=False)
+        _exec_command(
+            command=["docker", "container", "rm", "--force", container_name],
+            log_path=log_path,
+            check=False,
+        )
+
+
+def _run_lupine_case(*, config: GpuValidationConfig, case: GpuValidationCase) -> None:
+    if case.server_image is None:
+        raise ValueError(f"Incomplete Lupine case: {case}")
+
+    log_path = config.run_dir / f"{case.name}.log"
+    resource_prefix = _resource_prefix(config=config, case=case)
+    network_name = f"{resource_prefix}-network"
+    server_name = f"{resource_prefix}-server"
+    smoke_client_name = f"{resource_prefix}-smoke"
+    validation_client_name = f"{resource_prefix}-validation"
+    server_identity_logged = False
+    worker_identity_logged = False
+
+    try:
+        _exec_command(
+            command=["docker", "network", "create", network_name],
+            log_path=log_path,
+        )
+        _exec_command(
+            command=[
+                "docker",
+                "run",
+                "--rm",
+                "--pull",
+                "missing",
+                "--detach",
+                "--name",
+                server_name,
+                "--network",
+                network_name,
+                "--platform",
+                "linux/amd64",
+                "--gpus",
+                "device=0",
+                case.server_image,
+            ],
+            log_path=log_path,
+        )
+        _inspect_image(image=case.server_image, log_path=log_path)
+        server_identity_logged = True
+        client_prefix = [
+            "docker",
+            "run",
+            "--rm",
+            "--pull",
+            "missing",
+            "--platform",
+            "linux/arm64",
+            "--network",
+            network_name,
+            "--add-host",
+            "host.docker.internal:host-gateway",
+            "-e",
+            f"LUPINE_SERVER={server_name}:14833",
+        ]
+        _exec_command(
+            command=[
+                *client_prefix,
+                "--name",
+                smoke_client_name,
+                case.image,
+                "bash",
+                "-lc",
+                "for attempt in $(seq 1 30); do timeout --signal=TERM --kill-after=5s 20s python3 -c 'import torch; assert torch.cuda.is_available(); print(torch.cuda.get_device_name(0))' && exit 0; sleep 2; done; exit 1",
+            ],
+            log_path=log_path,
+        )
+        _inspect_image(image=case.image, log_path=log_path)
+        worker_identity_logged = True
+        _exec_command(
+            command=[
+                *client_prefix,
+                "--name",
+                validation_client_name,
+                *_environment_args(
+                    config=config,
+                    case=case,
+                    proxy_url=_host_gateway_proxy_url(proxy_url=config.proxy_url),
+                ),
+                "-v",
+                f"{config.release_root}:/workspace:ro",
+                case.image,
+                "bash",
+                "-lc",
+                _ARM_VALIDATION_SCRIPT,
+            ],
+            log_path=log_path,
+        )
+    finally:
+        if not worker_identity_logged:
+            _inspect_image(image=case.image, log_path=log_path, check=False)
+        if not server_identity_logged:
+            _inspect_image(image=case.server_image, log_path=log_path, check=False)
+        for client_name in (smoke_client_name, validation_client_name):
+            _exec_command(
+                command=["docker", "container", "rm", "--force", client_name],
+                log_path=log_path,
+                check=False,
+            )
+        _exec_command(
+            command=["docker", "container", "rm", "--force", server_name],
+            log_path=log_path,
+            check=False,
+        )
+        _exec_command(
+            command=["docker", "network", "rm", network_name],
+            log_path=log_path,
+            check=False,
+        )
+
+
+def _environment_args(
+    *,
+    config: GpuValidationConfig,
+    case: GpuValidationCase,
+    proxy_url: str,
+) -> list[str]:
+    return [
+        argument
+        for name, value in (
+            ("http_proxy", proxy_url),
+            ("https_proxy", proxy_url),
+            ("TMS_RELEASE_VERSION", config.expected_version),
+            ("TMS_CUDA_MAJOR", case.cuda_major),
+        )
+        for argument in ("-e", f"{name}={value}")
+    ]
+
+
+def _host_gateway_proxy_url(*, proxy_url: str) -> str:
+    parsed = urlsplit(proxy_url)
+    if parsed.hostname not in {"127.0.0.1", "localhost"}:
+        return proxy_url
+    if parsed.port is None:
+        raise ValueError(f"Loopback proxy URL requires a port: {proxy_url}")
+
+    return urlunsplit(
+        (
+            parsed.scheme,
+            f"host.docker.internal:{parsed.port}",
+            parsed.path,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def _resource_prefix(*, config: GpuValidationConfig, case: GpuValidationCase) -> str:
+    digest = hashlib.sha256(str(config.run_dir).encode()).hexdigest()[:10]
+    return f"tms-{case.name}-{digest}"
+
+
+def _inspect_image(*, image: str, log_path: Path, check: bool = True) -> None:
+    try:
+        _exec_command(
+            command=[
+                "docker",
+                "image",
+                "inspect",
+                image,
+                "--format",
+                'image_id={{.Id}} repo_digests={{json .RepoDigests}} architecture={{.Architecture}} revision={{index .Config.Labels "org.opencontainers.image.revision"}}',
+            ],
+            log_path=log_path,
+            check=check,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        if check:
+            raise
+
+
+def _exec_command(
+    *,
+    command: list[str],
+    log_path: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    rendered_command = shlex.join(command)
+    typer.echo(f"EXEC: {rendered_command}")
+    with log_path.open(mode="a", encoding="utf-8") as output:
+        output.write(f"EXEC: {rendered_command}\n")
+        output.flush()
+        result = subprocess.run(
+            command,
+            check=False,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=_COMMAND_TIMEOUT_SECONDS,
+        )
+
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            returncode=result.returncode,
+            cmd=command,
+        )
+    return result
+
+
+if __name__ == "__main__":
+    app()

--- a/.claude/skills/tms-publish-release/scripts/gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/gpu_validation.py
@@ -498,14 +498,25 @@ def _exec_command(
     with log_path.open(mode="a", encoding="utf-8") as output:
         output.write(f"EXEC: {rendered_command}\n")
         output.flush()
-        result = subprocess.run(
-            command,
-            check=False,
-            stdout=output,
-            stderr=subprocess.STDOUT,
-            text=True,
-            timeout=_COMMAND_TIMEOUT_SECONDS,
-        )
+        try:
+            result = subprocess.run(
+                command,
+                check=False,
+                stdout=output,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=_COMMAND_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as error:
+            output.write(f"RESULT: timeout={error.timeout} seconds\n")
+            output.flush()
+            raise
+        except OSError as error:
+            output.write(f"RESULT: error={type(error).__name__}: {error}\n")
+            output.flush()
+            raise
+        output.write(f"RESULT: returncode={result.returncode}\n")
+        output.flush()
 
     if check and result.returncode != 0:
         raise subprocess.CalledProcessError(

--- a/.claude/skills/tms-publish-release/scripts/gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/gpu_validation.py
@@ -7,9 +7,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import platform
 import shlex
 import subprocess
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -29,6 +31,49 @@ _RUNTIME_TEST_MODULES = (
     "test_utils.py",
 )
 _BUILD_TOOL_TEST_MODULES = ("test_merge_cuda_wheels.py",)
+_MULTI_DEVICE_SKIP_REASON = "Multi-device test requires at least two devices"
+_XPU_SKIP_REASON = "XPU-specific path"
+_LUPINE_SKIP_REASON = (
+    "Lupine GPU-over-IP does not preserve native pinned-host or process RSS semantics"
+)
+_EXPECTED_SINGLE_GPU_SKIPS = (
+    *(
+        (
+            f"test/test_examples.py::{test_name}[{hook_mode}]",
+            _MULTI_DEVICE_SKIP_REASON,
+        )
+        for test_name in (
+            "test_cpu_backup_multi_device_mmap_restore",
+            "test_multi_device",
+        )
+        for hook_mode in ("preload", "torch")
+    ),
+    (
+        "test/test_examples.py::test_multi_device_torch_mode",
+        _MULTI_DEVICE_SKIP_REASON,
+    ),
+    *(
+        (f"test/test_examples.py::{test_name}", _XPU_SKIP_REASON)
+        for test_name in (
+            "test_disable_unsupported_xpu",
+            "test_resume_failure_injection_xpu",
+            "test_cleanup_failure_injection_xpu",
+            "test_free_failure_injection_xpu",
+            "test_multi_device_sync_xpu",
+            "test_memory_margin_unsupported_xpu",
+        )
+    ),
+)
+_EXPECTED_LUPINE_SKIPS = (
+    (
+        "test/test_examples.py::test_cpu_backup_preload_backend_from_env",
+        _LUPINE_SKIP_REASON,
+    ),
+    *(
+        (f"test/test_examples.py::test_disk_backup[{hook_mode}]", _LUPINE_SKIP_REASON)
+        for hook_mode in ("preload", "torch")
+    ),
+)
 _X86_VALIDATION_SCRIPT = r"""
 set -euxo pipefail
 python --version
@@ -51,9 +96,10 @@ python -m pip install --no-deps "/workspace/dist/torch_memory_saver-${TMS_RELEAS
 mkdir -p /validation/test
 cp -a /workspace/test/examples /validation/test/examples
 cp /workspace/test/test_configure_subprocess.py /workspace/test/test_examples.py /workspace/test/test_utils.py /validation/test/
+cp /workspace/.claude/skills/tms-publish-release/scripts/pytest_skip_gate.py /validation/pytest_skip_gate.py
 cd /validation
 python -c 'from pathlib import Path; import torch_memory_saver; path=Path(torch_memory_saver.__file__); print(path); assert "site-packages" in path.parts'
-CUDA_VISIBLE_DEVICES=0 timeout --signal=TERM --kill-after=30s 3600s python -m pytest test -vv -ra
+CUDA_VISIBLE_DEVICES=0 timeout --signal=TERM --kill-after=30s 3600s python -m pytest -p pytest_skip_gate test -vv -ra
 """.strip()
 _ARM_VALIDATION_SCRIPT = r"""
 set -euxo pipefail
@@ -64,6 +110,7 @@ python3 -m pip install --break-system-packages --no-deps "/workspace/dist/torch_
 mkdir -p /validation/test
 cp -a /workspace/test/examples /validation/test/examples
 cp /workspace/test/test_configure_subprocess.py /workspace/test/test_examples.py /workspace/test/test_utils.py /validation/test/
+cp /workspace/.claude/skills/tms-publish-release/scripts/pytest_skip_gate.py /validation/pytest_skip_gate.py
 cd /validation
 python3 - <<'PY'
 from pathlib import Path
@@ -101,7 +148,7 @@ PY
 CUDA_RUNTIME_LIB="$(python3 -c 'from pathlib import Path; import os, site; major=os.environ["TMS_CUDA_MAJOR"]; matches=[path for root in site.getsitepackages() for path in (Path(root) / "nvidia").glob(f"**/libcudart.so.{major}")]; assert matches, matches; print(":".join(sorted({str(path.parent) for path in matches})))')"
 export LD_LIBRARY_PATH="${CUDA_RUNTIME_LIB}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 echo "CUDA_RUNTIME_LIB=${CUDA_RUNTIME_LIB}"
-CUDA_VISIBLE_DEVICES=0 timeout --signal=TERM --kill-after=30s 3600s python3 -m pytest test -vv -ra
+CUDA_VISIBLE_DEVICES=0 timeout --signal=TERM --kill-after=30s 3600s python3 -m pytest -p pytest_skip_gate test -vv -ra
 """.strip()
 
 
@@ -119,6 +166,7 @@ class GpuValidationCase:
     image: str
     architecture: str
     cuda_major: str
+    expected_skips: tuple[tuple[str, str], ...]
     server_image: str | None = None
     test_environment: tuple[tuple[str, str], ...] = ()
 
@@ -129,18 +177,21 @@ _GPU_VALIDATION_CASES: tuple[GpuValidationCase, ...] = (
         image="docker.io/pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime",
         architecture="x86_64",
         cuda_major="12",
+        expected_skips=_EXPECTED_SINGLE_GPU_SKIPS,
     ),
     GpuValidationCase(
         name="x86_64-cuda13-gpu",
         image="docker.io/pytorch/pytorch:2.9.1-cuda13.0-cudnn9-runtime",
         architecture="x86_64",
         cuda_major="13",
+        expected_skips=_EXPECTED_SINGLE_GPU_SKIPS,
     ),
     GpuValidationCase(
         name="aarch64-cuda12-gpu",
         image="ghcr.io/lupinemachines/lupine-pytorch-worker@sha256:f152fbcb3e2eda5661abafdfb4f3024afe9b775eb702015b5df0527ca0b7f556",
         architecture="aarch64",
         cuda_major="12",
+        expected_skips=_EXPECTED_SINGLE_GPU_SKIPS + _EXPECTED_LUPINE_SKIPS,
         server_image="ghcr.io/lupinemachines/lupine-server@sha256:e6b1103392165e929ca7f4f910eeec9f0b0f7155c5ff65b7402ca083c6bf9d53",
         test_environment=(("TMS_TEST_LUPINE", "1"),),
     ),
@@ -149,6 +200,7 @@ _GPU_VALIDATION_CASES: tuple[GpuValidationCase, ...] = (
         image="ghcr.io/lupinemachines/lupine-pytorch-worker@sha256:a154530bfeed825e8c915be1b6129965f293dbf29ce4764441014dccf9c6c08a",
         architecture="aarch64",
         cuda_major="13",
+        expected_skips=_EXPECTED_SINGLE_GPU_SKIPS + _EXPECTED_LUPINE_SKIPS,
         server_image="ghcr.io/lupinemachines/lupine-server@sha256:f1d805e14e0b2da5d5912adeed72f3e1c7d0458082c3cbaf3ba9bb2346b869cd",
         test_environment=(("TMS_TEST_LUPINE", "1"),),
     ),
@@ -306,12 +358,16 @@ def _run_x86_case(*, config: GpuValidationConfig, case: GpuValidationCase) -> No
         _inspect_image(image=case.image, log_path=log_path)
         identity_logged = True
     finally:
+        primary_error = sys.exc_info()[1]
         if not identity_logged:
             _inspect_image(image=case.image, log_path=log_path, check=False)
-        _exec_command(
-            command=["docker", "container", "rm", "--force", container_name],
+        cleanup_errors = _run_cleanup_commands(
+            commands=[["docker", "container", "rm", "--force", container_name]],
             log_path=log_path,
-            check=False,
+        )
+        _raise_cleanup_errors_if_unmasked(
+            cleanup_errors=cleanup_errors,
+            primary_error=primary_error,
         )
 
 
@@ -404,25 +460,26 @@ def _run_lupine_case(*, config: GpuValidationConfig, case: GpuValidationCase) ->
             log_path=log_path,
         )
     finally:
+        primary_error = sys.exc_info()[1]
         if not worker_identity_logged:
             _inspect_image(image=case.image, log_path=log_path, check=False)
         if not server_identity_logged:
             _inspect_image(image=case.server_image, log_path=log_path, check=False)
-        for client_name in (smoke_client_name, validation_client_name):
-            _exec_command(
-                command=["docker", "container", "rm", "--force", client_name],
-                log_path=log_path,
-                check=False,
-            )
-        _exec_command(
-            command=["docker", "container", "rm", "--force", server_name],
+        cleanup_errors = _run_cleanup_commands(
+            commands=[
+                ["docker", "container", "logs", server_name],
+                *(
+                    ["docker", "container", "rm", "--force", client_name]
+                    for client_name in (smoke_client_name, validation_client_name)
+                ),
+                ["docker", "container", "rm", "--force", server_name],
+                ["docker", "network", "rm", network_name],
+            ],
             log_path=log_path,
-            check=False,
         )
-        _exec_command(
-            command=["docker", "network", "rm", network_name],
-            log_path=log_path,
-            check=False,
+        _raise_cleanup_errors_if_unmasked(
+            cleanup_errors=cleanup_errors,
+            primary_error=primary_error,
         )
 
 
@@ -439,6 +496,10 @@ def _environment_args(
             ("https_proxy", proxy_url),
             ("TMS_RELEASE_VERSION", config.expected_version),
             ("TMS_CUDA_MAJOR", case.cuda_major),
+            (
+                "TMS_EXPECTED_PYTEST_SKIPS",
+                json.dumps(dict(case.expected_skips), sort_keys=True),
+            ),
             *case.test_environment,
         )
         for argument in ("-e", f"{name}={value}")
@@ -485,6 +546,25 @@ def _inspect_image(*, image: str, log_path: Path, check: bool = True) -> None:
     except (OSError, subprocess.TimeoutExpired):
         if check:
             raise
+
+
+def _run_cleanup_commands(*, commands: list[list[str]], log_path: Path) -> list[str]:
+    errors: list[str] = []
+    for command in commands:
+        try:
+            _exec_command(command=command, log_path=log_path, check=False)
+        except (OSError, subprocess.TimeoutExpired) as error:
+            errors.append(f"{shlex.join(command)}: {type(error).__name__}: {error}")
+    return errors
+
+
+def _raise_cleanup_errors_if_unmasked(
+    *,
+    cleanup_errors: list[str],
+    primary_error: BaseException | None,
+) -> None:
+    if cleanup_errors and primary_error is None:
+        raise RuntimeError(f"Validation cleanup failed: {cleanup_errors}")
 
 
 def _exec_command(

--- a/.claude/skills/tms-publish-release/scripts/gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/gpu_validation.py
@@ -101,10 +101,7 @@ PY
 CUDA_RUNTIME_LIB="$(python3 -c 'from pathlib import Path; import os, site; major=os.environ["TMS_CUDA_MAJOR"]; matches=[path for root in site.getsitepackages() for path in (Path(root) / "nvidia").glob(f"**/libcudart.so.{major}")]; assert matches, matches; print(":".join(sorted({str(path.parent) for path in matches})))')"
 export LD_LIBRARY_PATH="${CUDA_RUNTIME_LIB}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 echo "CUDA_RUNTIME_LIB=${CUDA_RUNTIME_LIB}"
-CUDA_VISIBLE_DEVICES=0 timeout --signal=TERM --kill-after=30s 3600s python3 -m pytest test -vv -ra \
-  --deselect 'test/test_examples.py::test_cpu_backup_preload_backend_from_env' \
-  --deselect 'test/test_examples.py::test_disk_backup[preload]' \
-  --deselect 'test/test_examples.py::test_disk_backup[torch]'
+CUDA_VISIBLE_DEVICES=0 timeout --signal=TERM --kill-after=30s 3600s python3 -m pytest test -vv -ra
 """.strip()
 
 
@@ -123,6 +120,7 @@ class GpuValidationCase:
     architecture: str
     cuda_major: str
     server_image: str | None = None
+    test_environment: tuple[tuple[str, str], ...] = ()
 
 
 _GPU_VALIDATION_CASES: tuple[GpuValidationCase, ...] = (
@@ -144,6 +142,7 @@ _GPU_VALIDATION_CASES: tuple[GpuValidationCase, ...] = (
         architecture="aarch64",
         cuda_major="12",
         server_image="ghcr.io/lupinemachines/lupine-server@sha256:e6b1103392165e929ca7f4f910eeec9f0b0f7155c5ff65b7402ca083c6bf9d53",
+        test_environment=(("TMS_TEST_LUPINE", "1"),),
     ),
     GpuValidationCase(
         name="aarch64-cuda13-gpu",
@@ -151,6 +150,7 @@ _GPU_VALIDATION_CASES: tuple[GpuValidationCase, ...] = (
         architecture="aarch64",
         cuda_major="13",
         server_image="ghcr.io/lupinemachines/lupine-server@sha256:f1d805e14e0b2da5d5912adeed72f3e1c7d0458082c3cbaf3ba9bb2346b869cd",
+        test_environment=(("TMS_TEST_LUPINE", "1"),),
     ),
 )
 
@@ -439,6 +439,7 @@ def _environment_args(
             ("https_proxy", proxy_url),
             ("TMS_RELEASE_VERSION", config.expected_version),
             ("TMS_CUDA_MAJOR", case.cuda_major),
+            *case.test_environment,
         )
         for argument in ("-e", f"{name}={value}")
     ]

--- a/.claude/skills/tms-publish-release/scripts/gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/gpu_validation.py
@@ -74,6 +74,14 @@ _EXPECTED_LUPINE_SKIPS = (
         for hook_mode in ("preload", "torch")
     ),
 )
+_LUPINE_SMOKE_SCRIPT = r"""
+set -euxo pipefail
+for attempt in $(seq 1 30); do
+    timeout --signal=TERM --kill-after=5s 20s python3 -c 'import torch; assert torch.cuda.is_available(); print(torch.cuda.get_device_name(0))' && exit 0
+    sleep 2
+done
+exit 1
+""".strip()
 _X86_VALIDATION_SCRIPT = r"""
 set -euxo pipefail
 python --version
@@ -434,7 +442,7 @@ def _run_lupine_case(*, config: GpuValidationConfig, case: GpuValidationCase) ->
                 case.image,
                 "bash",
                 "-lc",
-                "for attempt in $(seq 1 30); do timeout --signal=TERM --kill-after=5s 20s python3 -c 'import torch; assert torch.cuda.is_available(); print(torch.cuda.get_device_name(0))' && exit 0; sleep 2; done; exit 1",
+                _LUPINE_SMOKE_SCRIPT,
             ],
             log_path=log_path,
         )

--- a/.claude/skills/tms-publish-release/scripts/pytest_skip_gate.py
+++ b/.claude/skills/tms-publish-release/scripts/pytest_skip_gate.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+
+@dataclass
+class SkipGate:
+    expected: dict[str, str]
+    actual: dict[str, str] = field(default_factory=dict)
+    duplicates: list[str] = field(default_factory=list)
+
+    def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:
+        self._record(report=report)
+
+    def pytest_collectreport(self, report: pytest.CollectReport) -> None:
+        self._record(report=report)
+
+    def pytest_sessionfinish(
+        self,
+        session: pytest.Session,
+        exitstatus: pytest.ExitCode,
+    ) -> None:
+        mismatch = _skip_mismatch(
+            expected=self.expected,
+            actual=self.actual,
+            duplicates=self.duplicates,
+        )
+        print(f"SKIP_GATE_ACTUAL={json.dumps(self.actual, sort_keys=True)}", flush=True)
+        if mismatch is None:
+            print("SKIP_GATE_RESULT=pass", flush=True)
+            return
+
+        print(f"SKIP_GATE_RESULT=fail {mismatch}", flush=True)
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+    def _record(self, *, report: Any) -> None:
+        if not report.skipped:
+            return
+        reason = _skip_reason(longrepr=report.longrepr)
+        if report.nodeid in self.actual:
+            self.duplicates.append(report.nodeid)
+        self.actual[report.nodeid] = reason
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    raw_expected = os.environ.get("TMS_EXPECTED_PYTEST_SKIPS")
+    if raw_expected is None:
+        raise pytest.UsageError("TMS_EXPECTED_PYTEST_SKIPS is required")
+    try:
+        expected = json.loads(raw_expected)
+    except json.JSONDecodeError as error:
+        raise pytest.UsageError(
+            "TMS_EXPECTED_PYTEST_SKIPS must be valid JSON"
+        ) from error
+    if not isinstance(expected, dict) or not all(
+        isinstance(nodeid, str) and isinstance(reason, str)
+        for nodeid, reason in expected.items()
+    ):
+        raise pytest.UsageError("TMS_EXPECTED_PYTEST_SKIPS must be a JSON string map")
+    config.pluginmanager.register(SkipGate(expected=expected), "tms-skip-gate")
+
+
+def _skip_reason(*, longrepr: Any) -> str:
+    reason = longrepr[2] if isinstance(longrepr, tuple) else str(longrepr)
+    return reason.removeprefix("Skipped: ")
+
+
+def _skip_mismatch(
+    *,
+    expected: dict[str, str],
+    actual: dict[str, str],
+    duplicates: list[str],
+) -> str | None:
+    missing = sorted(set(expected) - set(actual))
+    unexpected = sorted(set(actual) - set(expected))
+    wrong_reasons = {
+        nodeid: {"expected": expected[nodeid], "actual": actual[nodeid]}
+        for nodeid in sorted(set(expected) & set(actual))
+        if expected[nodeid] != actual[nodeid]
+    }
+    if not missing and not unexpected and not wrong_reasons and not duplicates:
+        return None
+    return json.dumps(
+        {
+            "missing": missing,
+            "unexpected": unexpected,
+            "wrong_reasons": wrong_reasons,
+            "duplicates": sorted(duplicates),
+        },
+        sort_keys=True,
+    )

--- a/.claude/skills/tms-publish-release/scripts/release_checks.py
+++ b/.claude/skills/tms-publish-release/scripts/release_checks.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["click", "typer"]
+# ///
+
+from __future__ import annotations
+
+import ast
+import re
+import shlex
+import subprocess
+import tarfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+import click
+import typer
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+_CANONICAL_VERSION_PATTERN = re.compile(
+    r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:(?:a|b|rc)(?:0|[1-9]\d*)|\.post(?:0|[1-9]\d*))?$"
+)
+_ARCHITECTURES = ("x86_64", "aarch64")
+_ELF_MACHINE_BY_ARCHITECTURE = {"x86_64": 62, "aarch64": 183}
+_PYPI_RELEASE_URL = "https://pypi.org/pypi/torch-memory-saver/{version}/json"
+_EXPECTED_BINARY_NAMES = {
+    f"torch_memory_saver_hook_mode_{hook_mode}{suffix}.abi3.so"
+    for hook_mode in ("preload", "torch")
+    for suffix in ("", "_cu12", "_cu13")
+}
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@app.command("version")
+def _version_command(
+    setup_py: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=True, dir_okay=False, readable=True),
+    ],
+    expected_version: Annotated[str, typer.Option()],
+) -> None:
+    version = read_setup_version(setup_py=setup_py)
+    validate_canonical_version(version=version)
+    if version != expected_version:
+        raise typer.BadParameter(
+            f"setup.py version mismatch: expected {expected_version!r}, found {version!r}",
+            param_hint="--expected-version",
+        )
+    typer.echo(f"Validated canonical setup.py version: {version}")
+
+
+@app.command("pypi")
+def _pypi_command(
+    expected_version: Annotated[str, typer.Option()],
+) -> None:
+    validate_canonical_version(version=expected_version)
+    try:
+        version_exists = pypi_version_exists(version=expected_version)
+    except RuntimeError as error:
+        raise click.ClickException(str(error)) from error
+
+    if version_exists:
+        raise typer.BadParameter(
+            f"torch-memory-saver {expected_version!r} already exists on PyPI",
+            param_hint="--expected-version",
+        )
+    typer.echo(f"Confirmed PyPI version is available: {expected_version}")
+
+
+@app.command("publish-preflight")
+def _publish_preflight_command(
+    expected_version: Annotated[str, typer.Option()],
+    remote: Annotated[str, typer.Option()] = "origin",
+    repository: Annotated[str, typer.Option()] = "fzyzcjy/torch_memory_saver",
+) -> None:
+    validate_canonical_version(version=expected_version)
+    try:
+        collisions = find_publish_collisions(
+            version=expected_version,
+            remote=remote,
+            repository=repository,
+        )
+    except RuntimeError as error:
+        raise click.ClickException(str(error)) from error
+    if collisions:
+        raise typer.BadParameter(
+            f"Release identity already exists: {', '.join(collisions)}",
+            param_hint="--expected-version",
+        )
+    typer.echo(
+        f"Confirmed publish identity is unused on PyPI, {remote}, and GitHub: {expected_version}"
+    )
+
+
+@app.command("artifacts")
+def _artifacts_command(
+    dist_dir: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=False, dir_okay=True, readable=True),
+    ],
+    expected_version: Annotated[str, typer.Option()],
+    repo_root: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=False, dir_okay=True, readable=True),
+    ] = Path("."),
+) -> None:
+    validate_release_artifacts(
+        dist_dir=dist_dir,
+        expected_version=expected_version,
+        repo_root=repo_root,
+    )
+    typer.echo(f"Validated release artifacts for {expected_version}: {dist_dir}")
+
+
+@app.command("sdist")
+def _sdist_command(
+    sdist_path: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=True, dir_okay=False, readable=True),
+    ],
+    expected_version: Annotated[str, typer.Option()],
+    repo_root: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=False, dir_okay=True, readable=True),
+    ] = Path("."),
+) -> None:
+    validate_sdist(
+        sdist_path=sdist_path,
+        expected_version=expected_version,
+        repo_root=repo_root,
+    )
+    typer.echo(f"Validated source distribution for {expected_version}: {sdist_path}")
+
+
+def read_setup_version(*, setup_py: Path) -> str:
+    tree = ast.parse(setup_py.read_text(), filename=str(setup_py))
+    versions = [
+        keyword.value.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_setup_call(node=node)
+        for keyword in node.keywords
+        if keyword.arg == "version"
+        and isinstance(keyword.value, ast.Constant)
+        and isinstance(keyword.value.value, str)
+    ]
+
+    if len(versions) != 1:
+        raise ValueError(
+            f"Expected exactly one literal setup(version=...), found {versions}"
+        )
+    return versions[0]
+
+
+def validate_canonical_version(*, version: str) -> None:
+    if not _CANONICAL_VERSION_PATTERN.fullmatch(version):
+        raise ValueError(
+            f"Version {version!r} is not canonical for TMS; use X.Y.Z, X.Y.ZbN, "
+            "X.Y.ZrcN, or X.Y.Z.postN"
+        )
+
+
+def pypi_version_exists(*, version: str) -> bool:
+    url = _PYPI_RELEASE_URL.format(version=version)
+    try:
+        with urlopen(url, timeout=20):
+            return True
+    except HTTPError as error:
+        if error.code == 404:
+            return False
+        raise RuntimeError(
+            f"PyPI returned HTTP {error.code} while checking {version!r}"
+        ) from error
+    except URLError as error:
+        raise RuntimeError(
+            f"Could not query PyPI for {version!r}: {error.reason}"
+        ) from error
+
+
+def find_publish_collisions(*, version: str, remote: str, repository: str) -> list[str]:
+    collisions: list[str] = []
+    if pypi_version_exists(version=version):
+        collisions.append(f"PyPI version {version}")
+    if remote_tag_exists(version=version, remote=remote):
+        collisions.append(f"{remote} tag v{version}")
+    if github_release_exists(version=version, repository=repository):
+        collisions.append(f"GitHub Release v{version}")
+    return collisions
+
+
+def remote_tag_exists(*, version: str, remote: str) -> bool:
+    result = _exec_command(
+        command=[
+            "git",
+            "ls-remote",
+            "--exit-code",
+            "--tags",
+            remote,
+            f"refs/tags/v{version}",
+        ]
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 2:
+        return False
+    raise RuntimeError(
+        f"Could not check {remote} for tag v{version}: {result.stderr.strip()}"
+    )
+
+
+def github_release_exists(*, version: str, repository: str) -> bool:
+    result = _exec_command(
+        command=[
+            "gh",
+            "api",
+            "--silent",
+            f"repos/{repository}/releases/tags/v{version}",
+        ]
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1 and "HTTP 404" in result.stderr:
+        return False
+    raise RuntimeError(
+        f"Could not check {repository} for GitHub Release v{version}: {result.stderr.strip()}"
+    )
+
+
+def validate_release_artifacts(
+    *,
+    dist_dir: Path,
+    expected_version: str,
+    repo_root: Path,
+) -> None:
+    validate_canonical_version(version=expected_version)
+    expected_names = {
+        f"torch_memory_saver-{expected_version}-cp39-abi3-manylinux2014_{architecture}.whl"
+        for architecture in _ARCHITECTURES
+    } | {f"torch_memory_saver-{expected_version}.tar.gz"}
+    actual_names = {path.name for path in dist_dir.iterdir() if path.is_file()}
+
+    if actual_names != expected_names:
+        missing = sorted(expected_names - actual_names)
+        unexpected = sorted(actual_names - expected_names)
+        raise ValueError(
+            f"Release artifact set mismatch: missing={missing}, unexpected={unexpected}"
+        )
+
+    for architecture in _ARCHITECTURES:
+        validate_wheel(
+            wheel_path=dist_dir
+            / f"torch_memory_saver-{expected_version}-cp39-abi3-manylinux2014_{architecture}.whl",
+            expected_version=expected_version,
+            expected_architecture=architecture,
+        )
+    validate_sdist(
+        sdist_path=dist_dir / f"torch_memory_saver-{expected_version}.tar.gz",
+        expected_version=expected_version,
+        repo_root=repo_root,
+    )
+
+
+def validate_wheel(
+    *,
+    wheel_path: Path,
+    expected_version: str,
+    expected_architecture: str,
+) -> None:
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = set(wheel.namelist())
+        binary_paths = sorted(name for name in names if name.endswith(".so"))
+        binary_path_by_name = {Path(name).name: name for name in binary_paths}
+        binary_names = set(binary_path_by_name)
+        if binary_names != _EXPECTED_BINARY_NAMES:
+            missing = sorted(_EXPECTED_BINARY_NAMES - binary_names)
+            unexpected = sorted(binary_names - _EXPECTED_BINARY_NAMES)
+            raise ValueError(
+                f"Wheel binary set mismatch in {wheel_path.name}: "
+                f"missing={missing}, unexpected={unexpected}"
+            )
+
+        expected_machine = _ELF_MACHINE_BY_ARCHITECTURE[expected_architecture]
+        for binary_path in binary_paths:
+            machine = _read_elf_machine(
+                binary=wheel.read(binary_path),
+                source=f"{wheel_path.name}:{binary_path}",
+            )
+            if machine != expected_machine:
+                raise ValueError(
+                    f"ELF machine mismatch in {wheel_path.name}:{binary_path}: "
+                    f"expected {expected_machine}, found {machine}"
+                )
+
+        for hook_mode in ("preload", "torch"):
+            compatibility_name = f"torch_memory_saver_hook_mode_{hook_mode}.abi3.so"
+            cuda12_name = f"torch_memory_saver_hook_mode_{hook_mode}_cu12.abi3.so"
+            if wheel.read(binary_path_by_name[compatibility_name]) != wheel.read(
+                binary_path_by_name[cuda12_name]
+            ):
+                raise ValueError(
+                    f"CUDA 12 compatibility binary differs in {wheel_path.name}: "
+                    f"{compatibility_name} != {cuda12_name}"
+                )
+
+        metadata_name = _find_one(names=names, suffix=".dist-info/METADATA")
+        wheel_metadata_name = _find_one(names=names, suffix=".dist-info/WHEEL")
+        metadata = wheel.read(metadata_name).decode()
+        wheel_metadata = wheel.read(wheel_metadata_name).decode()
+
+    _validate_metadata_version(
+        metadata=metadata,
+        expected_version=expected_version,
+        source=wheel_path.name,
+    )
+    expected_tag = f"Tag: cp39-abi3-manylinux2014_{expected_architecture}"
+    if expected_tag not in wheel_metadata:
+        raise ValueError(
+            f"Missing {expected_tag!r} in {wheel_path.name} WHEEL metadata"
+        )
+
+
+def validate_sdist(*, sdist_path: Path, expected_version: str, repo_root: Path) -> None:
+    with tarfile.open(sdist_path, mode="r:gz") as sdist:
+        names = set(sdist.getnames())
+        package_info_name = _find_sdist_package_info(names=names)
+        package_info_file = sdist.extractfile(package_info_name)
+        if package_info_file is None:
+            raise ValueError(
+                f"Could not read {package_info_name} from {sdist_path.name}"
+            )
+        metadata = package_info_file.read().decode()
+
+    relative_names = {name.split("/", 1)[1] for name in names if "/" in name}
+    expected_sources = {
+        path.relative_to(repo_root).as_posix()
+        for path in (repo_root / "csrc").iterdir()
+        if path.is_file() and path.suffix in {".cpp", ".h"}
+    }
+    if not expected_sources:
+        raise ValueError(f"No C++ or header sources found under {repo_root / 'csrc'}")
+    if missing_sources := sorted(expected_sources - relative_names):
+        raise ValueError(
+            f"Source distribution is missing backend sources: {missing_sources}"
+        )
+
+    _validate_metadata_version(
+        metadata=metadata,
+        expected_version=expected_version,
+        source=sdist_path.name,
+    )
+
+
+def _is_setup_call(*, node: ast.Call) -> bool:
+    return isinstance(node.func, ast.Name) and node.func.id == "setup"
+
+
+def _find_one(*, names: set[str], suffix: str) -> str:
+    matches = sorted(name for name in names if name.endswith(suffix))
+    if len(matches) != 1:
+        raise ValueError(
+            f"Expected exactly one file ending in {suffix!r}, found {matches}"
+        )
+    return matches[0]
+
+
+def _find_sdist_package_info(*, names: set[str]) -> str:
+    matches = sorted(
+        name for name in names if name.count("/") == 1 and name.endswith("/PKG-INFO")
+    )
+    if len(matches) != 1:
+        raise ValueError(f"Expected exactly one root PKG-INFO, found {matches}")
+    return matches[0]
+
+
+def _read_elf_machine(*, binary: bytes, source: str) -> int:
+    if len(binary) < 20 or binary[:4] != b"\x7fELF":
+        raise ValueError(f"Invalid ELF binary in {source}")
+    if binary[5] not in {1, 2}:
+        raise ValueError(f"Invalid ELF byte order in {source}: {binary[5]}")
+
+    byte_order = "little" if binary[5] == 1 else "big"
+    return int.from_bytes(binary[18:20], byteorder=byte_order)
+
+
+def _validate_metadata_version(
+    *, metadata: str, expected_version: str, source: str
+) -> None:
+    version_lines = [
+        line for line in metadata.splitlines() if line.startswith("Version: ")
+    ]
+    expected_line = f"Version: {expected_version}"
+    if version_lines != [expected_line]:
+        raise ValueError(
+            f"Version metadata mismatch in {source}: expected {expected_line!r}, found {version_lines}"
+        )
+
+
+def _exec_command(*, command: list[str]) -> CommandResult:
+    typer.echo(f"EXEC: {shlex.join(command)}", err=True)
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return CommandResult(
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/.claude/skills/tms-publish-release/scripts/release_checks.py
+++ b/.claude/skills/tms-publish-release/scripts/release_checks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["click", "typer"]
+# dependencies = ["click", "twine", "typer"]
 # ///
 
 from __future__ import annotations
@@ -13,8 +13,11 @@ import hashlib
 import re
 import shlex
 import subprocess
+import sys
 import tarfile
+import traceback
 import zipfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
@@ -57,14 +60,14 @@ def _version_command(
     ],
     expected_version: Annotated[str, typer.Option()],
 ) -> None:
-    version = read_setup_version(setup_py=setup_py)
-    validate_canonical_version(version=version)
-    if version != expected_version:
-        raise typer.BadParameter(
-            f"setup.py version mismatch: expected {expected_version!r}, found {version!r}",
-            param_hint="--expected-version",
+    try:
+        validate_setup_version(
+            setup_py=setup_py,
+            expected_version=expected_version,
         )
-    typer.echo(f"Validated canonical setup.py version: {version}")
+    except ValueError as error:
+        raise typer.BadParameter(str(error), param_hint="--expected-version") from error
+    typer.echo(f"Validated canonical setup.py version: {expected_version}")
 
 
 @app.command("pypi")
@@ -108,6 +111,40 @@ def _publish_preflight_command(
     typer.echo(
         f"Confirmed publish identity is unused on PyPI, {remote}, and GitHub: {expected_version}"
     )
+
+
+@app.command("pre-upload")
+def _pre_upload_command(
+    dist_dir: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=False, dir_okay=True, readable=True),
+    ],
+    manifest: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=True, dir_okay=False, readable=True),
+    ],
+    expected_version: Annotated[str, typer.Option()],
+    log_path: Annotated[Path, typer.Option(file_okay=True, dir_okay=False)],
+    repo_root: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=False, dir_okay=True, readable=True),
+    ] = Path("."),
+    remote: Annotated[str, typer.Option()] = "origin",
+    repository: Annotated[str, typer.Option()] = "fzyzcjy/torch_memory_saver",
+) -> None:
+    try:
+        run_pre_upload_checks(
+            dist_dir=dist_dir,
+            manifest=manifest,
+            expected_version=expected_version,
+            log_path=log_path,
+            repo_root=repo_root,
+            remote=remote,
+            repository=repository,
+        )
+    except (OSError, RuntimeError, ValueError, subprocess.TimeoutExpired) as error:
+        raise click.ClickException(str(error)) from error
+    typer.echo(f"Completed every pre-upload check: {log_path}")
 
 
 @app.command("artifacts")
@@ -213,6 +250,15 @@ def read_setup_version(*, setup_py: Path) -> str:
             f"Expected exactly one literal setup(version=...), found {versions}"
         )
     return versions[0]
+
+
+def validate_setup_version(*, setup_py: Path, expected_version: str) -> None:
+    version = read_setup_version(setup_py=setup_py)
+    validate_canonical_version(version=version)
+    if version != expected_version:
+        raise ValueError(
+            f"setup.py version mismatch: expected {expected_version!r}, found {version!r}"
+        )
 
 
 def validate_canonical_version(*, version: str) -> None:
@@ -510,6 +556,119 @@ def run_logged_command(*, command: list[str], log_path: Path) -> int:
         output.write(f"RESULT: returncode={result.returncode}\n")
         output.flush()
     return result.returncode
+
+
+def run_pre_upload_checks(
+    *,
+    dist_dir: Path,
+    manifest: Path,
+    expected_version: str,
+    log_path: Path,
+    repo_root: Path,
+    remote: str,
+    repository: str,
+) -> None:
+    validate_canonical_version(version=expected_version)
+    git_script = r"""
+set -euxo pipefail
+git -C "$2" fetch "$1" master
+git -C "$2" status --short --branch
+test -z "$(git -C "$2" status --porcelain)"
+git -C "$2" rev-parse HEAD
+git -C "$2" rev-parse "$1/master"
+test "$(git -C "$2" rev-parse HEAD)" = "$(git -C "$2" rev-parse "$1/master")"
+""".strip()
+    if (
+        returncode := run_logged_command(
+            command=[
+                "bash",
+                "-lc",
+                git_script,
+                "tms-pre-upload",
+                remote,
+                str(repo_root),
+            ],
+            log_path=log_path,
+        )
+    ) != 0:
+        raise RuntimeError(f"Git pre-upload checks failed with exit code {returncode}")
+
+    _run_logged_validation(
+        name="version",
+        arguments=[expected_version, str(repo_root / "setup.py")],
+        log_path=log_path,
+        validation=lambda: validate_setup_version(
+            setup_py=repo_root / "setup.py",
+            expected_version=expected_version,
+        ),
+    )
+    _run_logged_validation(
+        name="verify-manifest",
+        arguments=[str(manifest), str(dist_dir)],
+        log_path=log_path,
+        validation=lambda: verify_sha256_manifest(
+            dist_dir=dist_dir,
+            manifest=manifest,
+        ),
+    )
+    _run_logged_validation(
+        name="artifacts",
+        arguments=[expected_version, str(dist_dir), str(repo_root)],
+        log_path=log_path,
+        validation=lambda: validate_release_artifacts(
+            dist_dir=dist_dir,
+            expected_version=expected_version,
+            repo_root=repo_root,
+        ),
+    )
+    artifact_paths = sorted(path for path in dist_dir.iterdir() if path.is_file())
+    if (
+        returncode := run_logged_command(
+            command=[sys.executable, "-m", "twine", "check", *map(str, artifact_paths)],
+            log_path=log_path,
+        )
+    ) != 0:
+        raise RuntimeError(f"Twine check failed with exit code {returncode}")
+
+    def validate_namespaces() -> None:
+        if collisions := find_publish_collisions(
+            version=expected_version,
+            remote=remote,
+            repository=repository,
+        ):
+            raise ValueError(
+                f"Release identity already exists: {', '.join(collisions)}"
+            )
+
+    _run_logged_validation(
+        name="publish-preflight",
+        arguments=[expected_version, remote, repository],
+        log_path=log_path,
+        validation=validate_namespaces,
+    )
+
+
+def _run_logged_validation(
+    *,
+    name: str,
+    arguments: list[str],
+    log_path: Path,
+    validation: Callable[[], None],
+) -> None:
+    rendered_command = shlex.join(["release_checks", name, *arguments])
+    typer.echo(f"EXEC: {rendered_command}", err=True)
+    with log_path.open(mode="a", encoding="utf-8") as output:
+        output.write(f"EXEC: {rendered_command}\n")
+        output.flush()
+        try:
+            validation()
+        except Exception as error:
+            traceback.print_exc(file=output)
+            output.write(f"RESULT: error={type(error).__name__}: {error}\n")
+            output.flush()
+            raise
+        output.write("RESULT: returncode=0\n")
+        output.flush()
 
 
 def validate_sdist(*, sdist_path: Path, expected_version: str, repo_root: Path) -> None:

--- a/.claude/skills/tms-publish-release/scripts/release_checks.py
+++ b/.claude/skills/tms-publish-release/scripts/release_checks.py
@@ -7,12 +7,16 @@
 from __future__ import annotations
 
 import ast
+import base64
+import csv
+import hashlib
 import re
 import shlex
 import subprocess
 import tarfile
 import zipfile
 from dataclasses import dataclass
+from io import StringIO
 from pathlib import Path
 from typing import Annotated
 from urllib.error import HTTPError, URLError
@@ -30,6 +34,7 @@ _CANONICAL_VERSION_PATTERN = re.compile(
 _ARCHITECTURES = ("x86_64", "aarch64")
 _ELF_MACHINE_BY_ARCHITECTURE = {"x86_64": 62, "aarch64": 183}
 _PYPI_RELEASE_URL = "https://pypi.org/pypi/torch-memory-saver/{version}/json"
+_COMMAND_TIMEOUT_SECONDS = 7200
 _EXPECTED_BINARY_NAMES = {
     f"torch_memory_saver_hook_mode_{hook_mode}{suffix}.abi3.so"
     for hook_mode in ("preload", "torch")
@@ -125,6 +130,33 @@ def _artifacts_command(
     typer.echo(f"Validated release artifacts for {expected_version}: {dist_dir}")
 
 
+@app.command("write-manifest")
+def _write_manifest_command(
+    dist_dir: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=False, dir_okay=True, readable=True),
+    ],
+    output: Annotated[Path, typer.Option(file_okay=True, dir_okay=False)],
+) -> None:
+    write_sha256_manifest(dist_dir=dist_dir, output=output)
+    typer.echo(f"Wrote release artifact manifest: {output}")
+
+
+@app.command("verify-manifest")
+def _verify_manifest_command(
+    dist_dir: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=False, dir_okay=True, readable=True),
+    ],
+    manifest: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=True, dir_okay=False, readable=True),
+    ],
+) -> None:
+    verify_sha256_manifest(dist_dir=dist_dir, manifest=manifest)
+    typer.echo(f"Verified release artifact manifest: {manifest}")
+
+
 @app.command("sdist")
 def _sdist_command(
     sdist_path: Annotated[
@@ -143,6 +175,25 @@ def _sdist_command(
         repo_root=repo_root,
     )
     typer.echo(f"Validated source distribution for {expected_version}: {sdist_path}")
+
+
+@app.command(
+    "run",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def _run_command(
+    context: typer.Context,
+    log_path: Annotated[Path, typer.Option(file_okay=True, dir_okay=False)],
+) -> None:
+    command = list(context.args)
+    if not command:
+        raise typer.BadParameter("A command is required after --")
+    try:
+        returncode = run_logged_command(command=command, log_path=log_path)
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise click.ClickException(str(error)) from error
+    if returncode != 0:
+        raise typer.Exit(code=returncode)
 
 
 def read_setup_version(*, setup_py: Path) -> str:
@@ -279,7 +330,10 @@ def validate_wheel(
     expected_architecture: str,
 ) -> None:
     with zipfile.ZipFile(wheel_path) as wheel:
-        names = set(wheel.namelist())
+        file_names = [name for name in wheel.namelist() if not name.endswith("/")]
+        names = set(file_names)
+        if len(file_names) != len(names):
+            raise ValueError(f"Duplicate file entry in {wheel_path.name}")
         binary_paths = sorted(name for name in names if name.endswith(".so"))
         binary_path_by_name = {Path(name).name: name for name in binary_paths}
         binary_names = set(binary_path_by_name)
@@ -316,6 +370,11 @@ def validate_wheel(
 
         metadata_name = _find_one(names=names, suffix=".dist-info/METADATA")
         wheel_metadata_name = _find_one(names=names, suffix=".dist-info/WHEEL")
+        _validate_wheel_record(
+            wheel=wheel,
+            names=names,
+            wheel_name=wheel_path.name,
+        )
         metadata = wheel.read(metadata_name).decode()
         wheel_metadata = wheel.read(wheel_metadata_name).decode()
 
@@ -329,6 +388,128 @@ def validate_wheel(
         raise ValueError(
             f"Missing {expected_tag!r} in {wheel_path.name} WHEEL metadata"
         )
+
+
+def _validate_wheel_record(
+    *,
+    wheel: zipfile.ZipFile,
+    names: set[str],
+    wheel_name: str,
+) -> None:
+    record_name = _find_one(names=names, suffix=".dist-info/RECORD")
+    rows = list(csv.reader(StringIO(wheel.read(record_name).decode("utf-8"))))
+    entries: dict[str, tuple[str, str]] = {}
+    for row_number, row in enumerate(rows, start=1):
+        if len(row) != 3:
+            raise ValueError(
+                f"Invalid RECORD row {row_number} in {wheel_name}: {row!r}"
+            )
+        path, digest, size = row
+        if path in entries:
+            raise ValueError(f"Duplicate RECORD path in {wheel_name}: {path}")
+        entries[path] = (digest, size)
+
+    if set(entries) != names:
+        missing = sorted(names - set(entries))
+        unexpected = sorted(set(entries) - names)
+        raise ValueError(
+            f"RECORD member set mismatch in {wheel_name}: missing={missing}, "
+            f"unexpected={unexpected}"
+        )
+    for path, (digest, size) in entries.items():
+        if path == record_name:
+            if digest or size:
+                raise ValueError(
+                    f"RECORD self-entry must omit hash and size in {wheel_name}"
+                )
+            continue
+
+        content = wheel.read(path)
+        expected_digest = (
+            base64.urlsafe_b64encode(hashlib.sha256(content).digest())
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        if digest != f"sha256={expected_digest}":
+            raise ValueError(f"RECORD hash mismatch in {wheel_name}: {path}")
+        if size != str(len(content)):
+            raise ValueError(f"RECORD size mismatch in {wheel_name}: {path}")
+
+
+def write_sha256_manifest(*, dist_dir: Path, output: Path) -> None:
+    if output.parent.resolve() == dist_dir.resolve():
+        raise ValueError("Release artifact manifest must be outside the dist directory")
+    artifact_paths = sorted(path for path in dist_dir.iterdir() if path.is_file())
+    if not artifact_paths:
+        raise ValueError(f"No release artifacts found in {dist_dir}")
+    if output.exists():
+        raise ValueError(f"Refusing to overwrite release artifact manifest: {output}")
+
+    lines = [
+        f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}"
+        for path in artifact_paths
+    ]
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def verify_sha256_manifest(*, dist_dir: Path, manifest: Path) -> None:
+    entries: dict[str, str] = {}
+    for line_number, line in enumerate(
+        manifest.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        match = re.fullmatch(r"([0-9a-f]{64})  ([^/]+)", line)
+        if match is None:
+            raise ValueError(
+                f"Invalid SHA-256 manifest line {line_number} in {manifest}: {line!r}"
+            )
+        digest, name = match.groups()
+        if name in entries:
+            raise ValueError(f"Duplicate artifact in SHA-256 manifest: {name}")
+        entries[name] = digest
+
+    actual_paths = {path.name: path for path in dist_dir.iterdir() if path.is_file()}
+    if set(entries) != set(actual_paths):
+        missing = sorted(set(entries) - set(actual_paths))
+        unexpected = sorted(set(actual_paths) - set(entries))
+        raise ValueError(
+            f"SHA-256 manifest artifact set mismatch: missing={missing}, "
+            f"unexpected={unexpected}"
+        )
+    for name, expected_digest in entries.items():
+        actual_digest = hashlib.sha256(actual_paths[name].read_bytes()).hexdigest()
+        if actual_digest != expected_digest:
+            raise ValueError(
+                f"SHA-256 mismatch for {name}: expected {expected_digest}, "
+                f"found {actual_digest}"
+            )
+
+
+def run_logged_command(*, command: list[str], log_path: Path) -> int:
+    rendered_command = shlex.join(command)
+    typer.echo(f"EXEC: {rendered_command}", err=True)
+    with log_path.open(mode="a", encoding="utf-8") as output:
+        output.write(f"EXEC: {rendered_command}\n")
+        output.flush()
+        try:
+            result = subprocess.run(
+                command,
+                check=False,
+                stdout=output,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=_COMMAND_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as error:
+            output.write(f"RESULT: timeout={error.timeout} seconds\n")
+            output.flush()
+            raise
+        except OSError as error:
+            output.write(f"RESULT: error={type(error).__name__}: {error}\n")
+            output.flush()
+            raise
+        output.write(f"RESULT: returncode={result.returncode}\n")
+        output.flush()
+    return result.returncode
 
 
 def validate_sdist(*, sdist_path: Path, expected_version: str, repo_root: Path) -> None:

--- a/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
@@ -1,0 +1,688 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _load_gpu_validation_module() -> ModuleType:
+    module_path = Path(__file__).with_name("gpu_validation.py")
+    spec = importlib.util.spec_from_file_location("gpu_validation", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gpu_validation = _load_gpu_validation_module()
+cli_runner = CliRunner()
+
+
+class TestGpuValidationCommand:
+    def test_command_builds_local_workstation_config(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The CLI builds a local Docker config without a remote option."""
+
+        release_root = tmp_path / "release"
+        artifact_root = tmp_path / "artifacts"
+        release_root.mkdir()
+        artifact_root.mkdir()
+        configs: list[gpu_validation.GpuValidationConfig] = []
+
+        def record_config(*, config: gpu_validation.GpuValidationConfig) -> None:
+            configs.append(config)
+
+        monkeypatch.setattr(
+            gpu_validation,
+            "run_gpu_validation",
+            record_config,
+        )
+
+        result = cli_runner.invoke(
+            gpu_validation.app,
+            [
+                "--release-root",
+                str(release_root),
+                "--artifact-root",
+                str(artifact_root),
+                "--expected-version",
+                "0.0.10b1",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert len(configs) == 1
+        assert configs[0].release_root == release_root
+        assert configs[0].run_dir.parent == artifact_root
+        assert "--remote" not in result.output
+
+    def test_matrix_maps_each_architecture_and_cuda_runtime_exactly(self) -> None:
+        """Every published binary family has one matching isolated GPU gate."""
+
+        assert [
+            (
+                case.name,
+                case.image,
+                case.architecture,
+                case.cuda_major,
+                case.server_image,
+            )
+            for case in gpu_validation._GPU_VALIDATION_CASES
+        ] == [
+            (
+                "x86_64-cuda12-gpu",
+                "docker.io/pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime",
+                "x86_64",
+                "12",
+                None,
+            ),
+            (
+                "x86_64-cuda13-gpu",
+                "docker.io/pytorch/pytorch:2.9.1-cuda13.0-cudnn9-runtime",
+                "x86_64",
+                "13",
+                None,
+            ),
+            (
+                "aarch64-cuda12-gpu",
+                "ghcr.io/lupinemachines/lupine-pytorch-worker@sha256:f152fbcb3e2eda5661abafdfb4f3024afe9b775eb702015b5df0527ca0b7f556",
+                "aarch64",
+                "12",
+                "ghcr.io/lupinemachines/lupine-server@sha256:e6b1103392165e929ca7f4f910eeec9f0b0f7155c5ff65b7402ca083c6bf9d53",
+            ),
+            (
+                "aarch64-cuda13-gpu",
+                "ghcr.io/lupinemachines/lupine-pytorch-worker@sha256:a154530bfeed825e8c915be1b6129965f293dbf29ce4764441014dccf9c6c08a",
+                "aarch64",
+                "13",
+                "ghcr.io/lupinemachines/lupine-server@sha256:f1d805e14e0b2da5d5912adeed72f3e1c7d0458082c3cbaf3ba9bb2346b869cd",
+            ),
+        ]
+
+    @pytest.mark.parametrize(
+        "script",
+        [
+            gpu_validation._X86_VALIDATION_SCRIPT,
+            gpu_validation._ARM_VALIDATION_SCRIPT,
+        ],
+    )
+    def test_gpu_scripts_run_runtime_suite_from_installed_wheel(
+        self, script: str
+    ) -> None:
+        """Each architecture installs the final wheel and exercises runtime tests."""
+
+        assert "pip install" in script
+        assert "--no-deps" in script
+        assert "test_configure_subprocess.py" in script
+        assert "test_examples.py" in script
+        assert "test_utils.py" in script
+        assert "pytest test -vv -ra" in script
+        assert "timeout --signal=TERM --kill-after=30s 3600s" in script
+        assert "torch.cuda.is_available()" in script
+        assert "get_device_name(0)" in script
+        assert '"4090 D" in name or "4090D" in name' in script
+        assert "site-packages" in script
+        assert "/workspace/scripts" not in script
+        assert "test_merge_cuda_wheels.py" not in script
+
+    def test_x86_script_runs_every_runtime_test(self) -> None:
+        """Direct NVIDIA validation does not exclude any runtime test."""
+
+        assert "--deselect" not in gpu_validation._X86_VALIDATION_SCRIPT
+
+    def test_arm_script_excludes_only_lupine_incompatible_tests(self) -> None:
+        """Lupine omits only tests invalidated by its host-memory emulation."""
+
+        script = gpu_validation._ARM_VALIDATION_SCRIPT
+
+        assert script.count("--deselect") == 3
+        assert (
+            "--deselect 'test/test_examples.py::test_cpu_backup_preload_backend_from_env'"
+            in script
+        )
+        assert (
+            "--deselect 'test/test_examples.py::test_disk_backup[preload]'" in script
+        )
+        assert "--deselect 'test/test_examples.py::test_disk_backup[torch]'" in script
+
+    def test_arm_script_requires_real_aarch64_gpu_execution(self) -> None:
+        """The ARM gate proves architecture, CUDA major, ELF type, and GPU access."""
+
+        script = gpu_validation._ARM_VALIDATION_SCRIPT
+
+        assert 'platform.machine() == "aarch64"' in script
+        assert '{"site-packages", "dist-packages"}' in script
+        assert "pytest==8.3.5" in script
+        assert "numpy==2.2.3" in script
+        assert "nvidia-ml-py==12.570.86" in script
+        assert "--only-binary=:all:" in script
+        assert "== 183" in script
+        assert "libcuda.so.1" not in script
+        assert "cuda-stubs" not in script
+
+    def test_cli_reports_validation_failure_without_secondary_exception(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed GPU command is rendered as one actionable CLI error."""
+
+        release_root = tmp_path / "release"
+        artifact_root = tmp_path / "artifacts"
+        release_root.mkdir()
+        artifact_root.mkdir()
+
+        def fail_validation(*, config: gpu_validation.GpuValidationConfig) -> None:
+            raise subprocess.CalledProcessError(returncode=7, cmd=["docker", "run"])
+
+        monkeypatch.setattr(
+            gpu_validation,
+            "run_gpu_validation",
+            fail_validation,
+        )
+
+        result = cli_runner.invoke(
+            gpu_validation.app,
+            [
+                "--release-root",
+                str(release_root),
+                "--artifact-root",
+                str(artifact_root),
+                "--expected-version",
+                "0.0.10b1",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert isinstance(
+            result.exception,
+            gpu_validation.click.ClickException,
+        )
+        message = str(result.exception)
+        assert "returned non-zero exit status 7" in message
+        assert "logs:" in message
+        assert "AttributeError" not in message
+
+    def test_runtime_test_classification_accepts_complete_inventory(
+        self, tmp_path: Path
+    ) -> None:
+        """Every repository test module is explicitly runtime or build tooling."""
+
+        _write_test_inventory(release_root=tmp_path)
+
+        gpu_validation._require_runtime_test_contract(release_root=tmp_path)
+
+    def test_runtime_test_classification_rejects_new_unclassified_module(
+        self, tmp_path: Path
+    ) -> None:
+        """A new test cannot silently escape clean-install GPU validation."""
+
+        _write_test_inventory(release_root=tmp_path)
+        (tmp_path / "test" / "test_new_runtime.py").touch()
+
+        with pytest.raises(ValueError, match="unclassified=.*test_new_runtime.py"):
+            gpu_validation._require_runtime_test_contract(release_root=tmp_path)
+
+    def test_missing_wheel_fails_before_docker(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A missing final wheel fails before any Docker command runs."""
+
+        release_root = tmp_path / "release"
+        artifact_root = tmp_path / "artifacts"
+        release_root.mkdir()
+        artifact_root.mkdir()
+        config = gpu_validation._build_config(
+            release_root=release_root,
+            artifact_root=artifact_root,
+            expected_version="0.0.10b1",
+            proxy_url="http://127.0.0.1:7890",
+        )
+        monkeypatch.setattr(gpu_validation.platform, "machine", lambda: "x86_64")
+
+        with pytest.raises(ValueError, match="Missing release wheels"):
+            gpu_validation.run_gpu_validation(config=config)
+
+    def test_validation_dispatches_all_four_gpu_cells(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The harness dispatches both direct and both Lupine GPU cells."""
+
+        config = _write_config_with_wheels(tmp_path=tmp_path)
+        dispatched: list[tuple[str, str]] = []
+
+        def complete_command(
+            *,
+            command: list[str],
+            log_path: Path,
+            check: bool = True,
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=command, returncode=0)
+
+        def record_x86(
+            *,
+            config: gpu_validation.GpuValidationConfig,
+            case: gpu_validation.GpuValidationCase,
+        ) -> None:
+            dispatched.append(("x86", case.name))
+
+        def record_lupine(
+            *,
+            config: gpu_validation.GpuValidationConfig,
+            case: gpu_validation.GpuValidationCase,
+        ) -> None:
+            dispatched.append(("lupine", case.name))
+
+        monkeypatch.setattr(gpu_validation.platform, "machine", lambda: "x86_64")
+        monkeypatch.setattr(gpu_validation, "_exec_command", complete_command)
+        monkeypatch.setattr(gpu_validation, "_run_x86_case", record_x86)
+        monkeypatch.setattr(gpu_validation, "_run_lupine_case", record_lupine)
+
+        gpu_validation.run_gpu_validation(config=config)
+
+        assert dispatched == [
+            ("x86", "x86_64-cuda12-gpu"),
+            ("x86", "x86_64-cuda13-gpu"),
+            ("lupine", "aarch64-cuda12-gpu"),
+            ("lupine", "aarch64-cuda13-gpu"),
+        ]
+
+    def test_x86_runner_uses_fresh_foreground_gpu_container(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Direct GPU validation is isolated, read-only, and foreground."""
+
+        config = _write_config_with_wheels(tmp_path=tmp_path)
+        case = gpu_validation._GPU_VALIDATION_CASES[0]
+        commands = _record_commands(monkeypatch=monkeypatch)
+
+        gpu_validation._run_x86_case(config=config, case=case)
+
+        run_command = commands[0][0]
+        assert run_command[:3] == ["docker", "run", "--rm"]
+        assert ["--pull", "missing"] == run_command[
+            run_command.index("--pull") : run_command.index("--pull") + 2
+        ]
+        assert "--detach" not in run_command
+        assert "--name" in run_command
+        assert ["--gpus", "device=0"] == run_command[
+            run_command.index("--gpus") : run_command.index("--gpus") + 2
+        ]
+        assert f"{config.release_root}:/workspace:ro" in run_command
+        assert f"TMS_CUDA_MAJOR={case.cuda_major}" in run_command
+        assert commands[1][0][:4] == ["docker", "image", "inspect", case.image]
+        assert "org.opencontainers.image.revision" in commands[1][0][-1]
+        assert commands[-1][0][:4] == ["docker", "container", "rm", "--force"]
+
+    def test_x86_runner_cleans_named_container_after_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A timed-out direct GPU gate still removes its named container."""
+
+        config = _write_config_with_wheels(tmp_path=tmp_path)
+        case = gpu_validation._GPU_VALIDATION_CASES[1]
+        commands: list[tuple[list[str], bool]] = []
+
+        def timeout_gpu_run(
+            *,
+            command: list[str],
+            log_path: Path,
+            check: bool = True,
+            input_text: str | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            commands.append((command, check))
+            if command[:3] == ["docker", "run", "--rm"]:
+                raise subprocess.TimeoutExpired(
+                    cmd=command,
+                    timeout=gpu_validation._COMMAND_TIMEOUT_SECONDS,
+                )
+            return subprocess.CompletedProcess(args=command, returncode=0)
+
+        monkeypatch.setattr(gpu_validation, "_exec_command", timeout_gpu_run)
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            gpu_validation._run_x86_case(config=config, case=case)
+
+        resource_prefix = gpu_validation._resource_prefix(
+            config=config,
+            case=case,
+        )
+        assert commands[-2][0][:4] == ["docker", "image", "inspect", case.image]
+        assert commands[-2][1] is False
+        assert commands[-1] == (
+            [
+                "docker",
+                "container",
+                "rm",
+                "--force",
+                f"{resource_prefix}-validation",
+            ],
+            False,
+        )
+
+    def test_lupine_runner_uses_published_worker_and_private_network(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ARM validation connects matched images without exposing the RPC port."""
+
+        config = _write_config_with_wheels(tmp_path=tmp_path)
+        case = gpu_validation._GPU_VALIDATION_CASES[2]
+        commands = _record_commands(monkeypatch=monkeypatch)
+
+        gpu_validation._run_lupine_case(config=config, case=case)
+
+        command_lists = [command for command, _ in commands]
+        server_command = next(
+            command
+            for command in command_lists
+            if command[:3] == ["docker", "run", "--rm"] and "--detach" in command
+        )
+        client_commands = [
+            command
+            for command in command_lists
+            if command[:3] == ["docker", "run", "--rm"]
+            and "--platform" in command
+            and "linux/arm64" in command
+        ]
+
+        assert command_lists[0][:3] == ["docker", "network", "create"]
+        assert command_lists[1] == server_command
+        assert command_lists[2][:4] == [
+            "docker",
+            "image",
+            "inspect",
+            case.server_image,
+        ]
+        assert command_lists[3] == client_commands[0]
+        assert command_lists[4][:4] == [
+            "docker",
+            "image",
+            "inspect",
+            case.image,
+        ]
+        assert command_lists[5] == client_commands[1]
+        assert not any(command[:2] == ["docker", "build"] for command in command_lists)
+        assert not any(command[:2] == ["docker", "pull"] for command in command_lists)
+        assert case.server_image in server_command
+        assert ["--gpus", "device=0"] == server_command[-3:-1]
+        assert "-p" not in server_command
+        assert "--publish" not in server_command
+        assert len(client_commands) == 2
+        for command in [server_command, *client_commands]:
+            pull_index = command.index("--pull")
+            assert command[pull_index : pull_index + 2] == ["--pull", "missing"]
+        for command in client_commands:
+            add_host_index = command.index("--add-host")
+            assert command[add_host_index : add_host_index + 2] == [
+                "--add-host",
+                "host.docker.internal:host-gateway",
+            ]
+        assert "--name" in client_commands[0]
+        assert "--name" in client_commands[1]
+        assert f"{config.release_root}:/workspace:ro" not in client_commands[0]
+        assert f"{config.release_root}:/workspace:ro" in client_commands[1]
+        assert f"TMS_CUDA_MAJOR={case.cuda_major}" in client_commands[1]
+        assert "http_proxy=http://host.docker.internal:7890" in client_commands[1]
+        assert "https_proxy=http://host.docker.internal:7890" in client_commands[1]
+        assert client_commands[0][-4] == case.image
+        assert client_commands[1][-4] == case.image
+        assert (
+            "timeout --signal=TERM --kill-after=5s 20s python3 -c"
+            in client_commands[0][-1]
+        )
+
+    def test_lupine_runner_records_worker_identity_after_smoke_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed worker smoke keeps its error and records the pulled image."""
+
+        config = _write_config_with_wheels(tmp_path=tmp_path)
+        case = gpu_validation._GPU_VALIDATION_CASES[2]
+        commands: list[tuple[list[str], bool]] = []
+
+        def fail_smoke(
+            *,
+            command: list[str],
+            log_path: Path,
+            check: bool = True,
+        ) -> subprocess.CompletedProcess[str]:
+            commands.append((command, check))
+            if command[:3] == ["docker", "run", "--rm"] and command[-1].startswith(
+                "for attempt in"
+            ):
+                raise subprocess.CalledProcessError(returncode=9, cmd=command)
+            return subprocess.CompletedProcess(args=command, returncode=0)
+
+        monkeypatch.setattr(gpu_validation, "_exec_command", fail_smoke)
+
+        with pytest.raises(subprocess.CalledProcessError) as error:
+            gpu_validation._run_lupine_case(config=config, case=case)
+
+        assert error.value.returncode == 9
+        smoke_index = next(
+            index
+            for index, (command, _) in enumerate(commands)
+            if command[:3] == ["docker", "run", "--rm"]
+            and command[-1].startswith("for attempt in")
+        )
+        assert commands[smoke_index + 1][0][:4] == [
+            "docker",
+            "image",
+            "inspect",
+            case.image,
+        ]
+        assert commands[smoke_index + 1][1] is False
+
+    @pytest.mark.parametrize(
+        ("proxy_url", "expected"),
+        [
+            (
+                "http://127.0.0.1:7890",
+                "http://host.docker.internal:7890",
+            ),
+            (
+                "http://localhost:7890",
+                "http://host.docker.internal:7890",
+            ),
+            (
+                "http://proxy.example.com:8080",
+                "http://proxy.example.com:8080",
+            ),
+        ],
+    )
+    def test_arm_proxy_resolves_host_loopback_from_bridge_network(
+        self,
+        proxy_url: str,
+        expected: str,
+    ) -> None:
+        """ARM dependency installs can reach the configured host proxy."""
+
+        assert gpu_validation._host_gateway_proxy_url(proxy_url=proxy_url) == expected
+
+    def test_loopback_proxy_without_port_is_rejected(self) -> None:
+        """A loopback proxy without a reachable host port fails before Docker."""
+
+        with pytest.raises(ValueError, match="requires a port"):
+            gpu_validation._host_gateway_proxy_url(proxy_url="http://127.0.0.1")
+
+    def test_lupine_runner_cleans_resources_after_client_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Server and private network are removed after a failed ARM gate."""
+
+        config = _write_config_with_wheels(tmp_path=tmp_path)
+        case = gpu_validation._GPU_VALIDATION_CASES[3]
+        commands: list[tuple[list[str], str | None, bool]] = []
+
+        def fail_final_client(
+            *,
+            command: list[str],
+            log_path: Path,
+            check: bool = True,
+        ) -> subprocess.CompletedProcess[str]:
+            commands.append((command, None, check))
+            if (
+                command[:3] == ["docker", "run", "--rm"]
+                and command[-1] == gpu_validation._ARM_VALIDATION_SCRIPT
+            ):
+                raise subprocess.CalledProcessError(returncode=1, cmd=command)
+            return subprocess.CompletedProcess(args=command, returncode=0)
+
+        monkeypatch.setattr(gpu_validation, "_exec_command", fail_final_client)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            gpu_validation._run_lupine_case(config=config, case=case)
+
+        resource_prefix = gpu_validation._resource_prefix(
+            config=config,
+            case=case,
+        )
+        assert [entry[0][:4] for entry in commands[-4:]] == [
+            ["docker", "container", "rm", "--force"],
+            ["docker", "container", "rm", "--force"],
+            ["docker", "container", "rm", "--force"],
+            ["docker", "network", "rm", commands[-1][0][3]],
+        ]
+        assert [entry[0][-1] for entry in commands[-4:]] == [
+            f"{resource_prefix}-smoke",
+            f"{resource_prefix}-validation",
+            f"{resource_prefix}-server",
+            f"{resource_prefix}-network",
+        ]
+        assert [entry[2] for entry in commands[-4:]] == [
+            False,
+            False,
+            False,
+            False,
+        ]
+
+    def test_exec_command_applies_orchestration_timeout(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Every external Docker command has a process-level hard timeout."""
+
+        captured_timeouts: list[float | None] = []
+
+        def complete_run(
+            command: list[str],
+            *,
+            check: bool,
+            stdout: object,
+            stderr: int,
+            text: bool,
+            timeout: float | None,
+        ) -> subprocess.CompletedProcess[str]:
+            captured_timeouts.append(timeout)
+            return subprocess.CompletedProcess(args=command, returncode=0)
+
+        monkeypatch.setattr(gpu_validation.subprocess, "run", complete_run)
+
+        gpu_validation._exec_command(
+            command=["docker", "info"],
+            log_path=tmp_path / "command.log",
+        )
+
+        assert captured_timeouts == [gpu_validation._COMMAND_TIMEOUT_SECONDS]
+
+    def test_best_effort_image_inspect_suppresses_timeout(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Failure-path image inspection cannot replace the primary error."""
+
+        def timeout_inspect(
+            *,
+            command: list[str],
+            log_path: Path,
+            check: bool = True,
+        ) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(command, timeout=1)
+
+        monkeypatch.setattr(gpu_validation, "_exec_command", timeout_inspect)
+
+        gpu_validation._inspect_image(
+            image="example.invalid/image:latest",
+            log_path=tmp_path / "inspect.log",
+            check=False,
+        )
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            gpu_validation._inspect_image(
+                image="example.invalid/image:latest",
+                log_path=tmp_path / "inspect.log",
+            )
+
+
+def _write_config_with_wheels(*, tmp_path: Path) -> gpu_validation.GpuValidationConfig:
+    release_root = tmp_path / "release"
+    artifact_root = tmp_path / "artifacts"
+    dist_dir = release_root / "dist"
+    dist_dir.mkdir(parents=True)
+    artifact_root.mkdir()
+    for architecture in ("x86_64", "aarch64"):
+        (
+            dist_dir
+            / f"torch_memory_saver-0.0.10b1-cp39-abi3-manylinux2014_{architecture}.whl"
+        ).touch()
+    _write_test_inventory(release_root=release_root)
+    return gpu_validation._build_config(
+        release_root=release_root,
+        artifact_root=artifact_root,
+        expected_version="0.0.10b1",
+        proxy_url="http://127.0.0.1:7890",
+    )
+
+
+def _write_test_inventory(*, release_root: Path) -> None:
+    test_dir = release_root / "test"
+    (test_dir / "examples").mkdir(parents=True)
+    for name in (
+        *gpu_validation._RUNTIME_TEST_MODULES,
+        *gpu_validation._BUILD_TOOL_TEST_MODULES,
+    ):
+        (test_dir / name).touch()
+
+
+def _record_commands(
+    *, monkeypatch: pytest.MonkeyPatch
+) -> list[tuple[list[str], str | None]]:
+    commands: list[tuple[list[str], str | None]] = []
+
+    def record_command(
+        *,
+        command: list[str],
+        log_path: Path,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        commands.append((command, None))
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(gpu_validation, "_exec_command", record_command)
+    return commands

--- a/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
@@ -168,6 +168,13 @@ class TestGpuValidationCommand:
         assert "--deselect" not in gpu_validation._X86_VALIDATION_SCRIPT
         assert "--deselect" not in gpu_validation._ARM_VALIDATION_SCRIPT
 
+    def test_every_inline_shell_script_enables_strict_mode(self) -> None:
+        """Every harness-owned inline shell starts in strict traced mode."""
+
+        assert gpu_validation._LUPINE_SMOKE_SCRIPT.startswith("set -euxo pipefail\n")
+        assert gpu_validation._X86_VALIDATION_SCRIPT.startswith("set -euxo pipefail\n")
+        assert gpu_validation._ARM_VALIDATION_SCRIPT.startswith("set -euxo pipefail\n")
+
     def test_lupine_runtime_tests_declare_exact_skip_markers(self) -> None:
         """Only the two host-memory tests opt out under Lupine."""
 
@@ -532,6 +539,7 @@ class TestGpuValidationCommand:
             "timeout --signal=TERM --kill-after=5s 20s python3 -c"
             in client_commands[0][-1]
         )
+        assert client_commands[0][-1] == gpu_validation._LUPINE_SMOKE_SCRIPT
 
     def test_lupine_runner_records_worker_identity_after_smoke_failure(
         self,
@@ -551,8 +559,9 @@ class TestGpuValidationCommand:
             check: bool = True,
         ) -> subprocess.CompletedProcess[str]:
             commands.append((command, check))
-            if command[:3] == ["docker", "run", "--rm"] and command[-1].startswith(
-                "for attempt in"
+            if (
+                command[:3] == ["docker", "run", "--rm"]
+                and command[-1] == gpu_validation._LUPINE_SMOKE_SCRIPT
             ):
                 raise subprocess.CalledProcessError(returncode=9, cmd=command)
             return subprocess.CompletedProcess(args=command, returncode=0)
@@ -567,7 +576,7 @@ class TestGpuValidationCommand:
             index
             for index, (command, _) in enumerate(commands)
             if command[:3] == ["docker", "run", "--rm"]
-            and command[-1].startswith("for attempt in")
+            and command[-1] == gpu_validation._LUPINE_SMOKE_SCRIPT
         )
         assert commands[smoke_index + 1][0][:4] == [
             "docker",

--- a/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -22,7 +23,19 @@ def _load_gpu_validation_module() -> ModuleType:
     return module
 
 
+def _load_pytest_skip_gate_module() -> ModuleType:
+    module_path = Path(__file__).with_name("pytest_skip_gate.py")
+    spec = importlib.util.spec_from_file_location("pytest_skip_gate", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 gpu_validation = _load_gpu_validation_module()
+pytest_skip_gate = _load_pytest_skip_gate_module()
 cli_runner = CliRunner()
 
 
@@ -76,6 +89,7 @@ class TestGpuValidationCommand:
                 case.image,
                 case.architecture,
                 case.cuda_major,
+                case.expected_skips,
                 case.server_image,
                 case.test_environment,
             )
@@ -86,6 +100,7 @@ class TestGpuValidationCommand:
                 "docker.io/pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime",
                 "x86_64",
                 "12",
+                gpu_validation._EXPECTED_SINGLE_GPU_SKIPS,
                 None,
                 (),
             ),
@@ -94,6 +109,7 @@ class TestGpuValidationCommand:
                 "docker.io/pytorch/pytorch:2.9.1-cuda13.0-cudnn9-runtime",
                 "x86_64",
                 "13",
+                gpu_validation._EXPECTED_SINGLE_GPU_SKIPS,
                 None,
                 (),
             ),
@@ -102,6 +118,8 @@ class TestGpuValidationCommand:
                 "ghcr.io/lupinemachines/lupine-pytorch-worker@sha256:f152fbcb3e2eda5661abafdfb4f3024afe9b775eb702015b5df0527ca0b7f556",
                 "aarch64",
                 "12",
+                gpu_validation._EXPECTED_SINGLE_GPU_SKIPS
+                + gpu_validation._EXPECTED_LUPINE_SKIPS,
                 "ghcr.io/lupinemachines/lupine-server@sha256:e6b1103392165e929ca7f4f910eeec9f0b0f7155c5ff65b7402ca083c6bf9d53",
                 (("TMS_TEST_LUPINE", "1"),),
             ),
@@ -110,6 +128,8 @@ class TestGpuValidationCommand:
                 "ghcr.io/lupinemachines/lupine-pytorch-worker@sha256:a154530bfeed825e8c915be1b6129965f293dbf29ce4764441014dccf9c6c08a",
                 "aarch64",
                 "13",
+                gpu_validation._EXPECTED_SINGLE_GPU_SKIPS
+                + gpu_validation._EXPECTED_LUPINE_SKIPS,
                 "ghcr.io/lupinemachines/lupine-server@sha256:f1d805e14e0b2da5d5912adeed72f3e1c7d0458082c3cbaf3ba9bb2346b869cd",
                 (("TMS_TEST_LUPINE", "1"),),
             ),
@@ -132,7 +152,7 @@ class TestGpuValidationCommand:
         assert "test_configure_subprocess.py" in script
         assert "test_examples.py" in script
         assert "test_utils.py" in script
-        assert "pytest test -vv -ra" in script
+        assert "pytest -p pytest_skip_gate test -vv -ra" in script
         assert "timeout --signal=TERM --kill-after=30s 3600s" in script
         assert "torch.cuda.is_available()" in script
         assert "get_device_name(0)" in script
@@ -140,6 +160,7 @@ class TestGpuValidationCommand:
         assert "site-packages" in script
         assert "/workspace/scripts" not in script
         assert "test_merge_cuda_wheels.py" not in script
+        assert "pytest_skip_gate.py /validation/pytest_skip_gate.py" in script
 
     def test_gpu_scripts_do_not_deselect_runtime_tests(self) -> None:
         """Runtime-specific skips remain visible in pytest output."""
@@ -158,8 +179,7 @@ class TestGpuValidationCommand:
             for node in tree.body
             if isinstance(node, ast.FunctionDef)
             and any(
-                isinstance(decorator, ast.Name)
-                and decorator.id == "_skip_on_lupine"
+                isinstance(decorator, ast.Name) and decorator.id == "_skip_on_lupine"
                 for decorator in node.decorator_list
             )
         }
@@ -169,6 +189,41 @@ class TestGpuValidationCommand:
             "test_cpu_backup_preload_backend_from_env",
             "test_disk_backup",
         }
+
+    def test_skip_gate_accepts_only_the_exact_node_and_reason_map(self) -> None:
+        """The structured skip gate rejects missing, extra, or changed skips."""
+
+        expected = {"test/example.py::test_case": "expected reason"}
+
+        assert (
+            pytest_skip_gate._skip_mismatch(
+                expected=expected,
+                actual=expected,
+                duplicates=[],
+            )
+            is None
+        )
+        for actual in (
+            {},
+            {**expected, "test/example.py::test_extra": "extra reason"},
+            {"test/example.py::test_case": "changed reason"},
+        ):
+            assert (
+                pytest_skip_gate._skip_mismatch(
+                    expected=expected,
+                    actual=actual,
+                    duplicates=[],
+                )
+                is not None
+            )
+        assert (
+            pytest_skip_gate._skip_mismatch(
+                expected=expected,
+                actual=expected,
+                duplicates=["test/example.py::test_case"],
+            )
+            is not None
+        )
 
     def test_arm_script_requires_real_aarch64_gpu_execution(self) -> None:
         """The ARM gate proves architecture, CUDA major, ELF type, and GPU access."""
@@ -342,6 +397,11 @@ class TestGpuValidationCommand:
         assert f"{config.release_root}:/workspace:ro" in run_command
         assert f"TMS_CUDA_MAJOR={case.cuda_major}" in run_command
         assert "TMS_TEST_LUPINE=1" not in run_command
+        assert (
+            "TMS_EXPECTED_PYTEST_SKIPS="
+            + json.dumps(dict(case.expected_skips), sort_keys=True)
+            in run_command
+        )
         assert commands[1][0][:4] == ["docker", "image", "inspect", case.image]
         assert "org.opencontainers.image.revision" in commands[1][0][-1]
         assert commands[-1][0][:4] == ["docker", "container", "rm", "--force"]
@@ -459,6 +519,11 @@ class TestGpuValidationCommand:
         assert f"{config.release_root}:/workspace:ro" in client_commands[1]
         assert f"TMS_CUDA_MAJOR={case.cuda_major}" in client_commands[1]
         assert "TMS_TEST_LUPINE=1" in client_commands[1]
+        assert (
+            "TMS_EXPECTED_PYTEST_SKIPS="
+            + json.dumps(dict(case.expected_skips), sort_keys=True)
+            in client_commands[1]
+        )
         assert "http_proxy=http://host.docker.internal:7890" in client_commands[1]
         assert "https_proxy=http://host.docker.internal:7890" in client_commands[1]
         assert client_commands[0][-4] == case.image
@@ -578,24 +643,103 @@ class TestGpuValidationCommand:
             config=config,
             case=case,
         )
-        assert [entry[0][:4] for entry in commands[-4:]] == [
+        assert [entry[0][:4] for entry in commands[-5:]] == [
+            ["docker", "container", "logs", f"{resource_prefix}-server"],
             ["docker", "container", "rm", "--force"],
             ["docker", "container", "rm", "--force"],
             ["docker", "container", "rm", "--force"],
             ["docker", "network", "rm", commands[-1][0][3]],
         ]
-        assert [entry[0][-1] for entry in commands[-4:]] == [
+        assert [entry[0][-1] for entry in commands[-5:]] == [
+            f"{resource_prefix}-server",
             f"{resource_prefix}-smoke",
             f"{resource_prefix}-validation",
             f"{resource_prefix}-server",
             f"{resource_prefix}-network",
         ]
-        assert [entry[2] for entry in commands[-4:]] == [
+        assert [entry[2] for entry in commands[-5:]] == [
+            False,
             False,
             False,
             False,
             False,
         ]
+
+    def test_cleanup_timeout_preserves_primary_error_and_continues(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """One cleanup timeout cannot mask failure or stop later cleanup."""
+
+        config = _write_config_with_wheels(tmp_path=tmp_path)
+        case = gpu_validation._GPU_VALIDATION_CASES[3]
+        cleanup_names: list[str] = []
+
+        def fail_validation_and_first_cleanup(
+            *,
+            command: list[str],
+            log_path: Path,
+            check: bool = True,
+        ) -> subprocess.CompletedProcess[str]:
+            if (
+                command[:3] == ["docker", "run", "--rm"]
+                and command[-1] == gpu_validation._ARM_VALIDATION_SCRIPT
+            ):
+                raise subprocess.CalledProcessError(returncode=23, cmd=command)
+            if command[:4] == ["docker", "container", "rm", "--force"]:
+                cleanup_names.append(command[-1])
+                if len(cleanup_names) == 1:
+                    raise subprocess.TimeoutExpired(command, timeout=1)
+            if command[:3] == ["docker", "network", "rm"]:
+                cleanup_names.append(command[-1])
+            return subprocess.CompletedProcess(args=command, returncode=0)
+
+        monkeypatch.setattr(
+            gpu_validation,
+            "_exec_command",
+            fail_validation_and_first_cleanup,
+        )
+
+        with pytest.raises(subprocess.CalledProcessError) as error:
+            gpu_validation._run_lupine_case(config=config, case=case)
+
+        resource_prefix = gpu_validation._resource_prefix(
+            config=config,
+            case=case,
+        )
+        assert error.value.returncode == 23
+        assert cleanup_names == [
+            f"{resource_prefix}-smoke",
+            f"{resource_prefix}-validation",
+            f"{resource_prefix}-server",
+            f"{resource_prefix}-network",
+        ]
+
+    def test_cleanup_timeout_fails_an_otherwise_successful_case(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A cleanup timeout remains visible when validation itself succeeded."""
+
+        config = _write_config_with_wheels(tmp_path=tmp_path)
+        case = gpu_validation._GPU_VALIDATION_CASES[0]
+
+        def timeout_cleanup(
+            *,
+            command: list[str],
+            log_path: Path,
+            check: bool = True,
+        ) -> subprocess.CompletedProcess[str]:
+            if command[:4] == ["docker", "container", "rm", "--force"]:
+                raise subprocess.TimeoutExpired(command, timeout=1)
+            return subprocess.CompletedProcess(args=command, returncode=0)
+
+        monkeypatch.setattr(gpu_validation, "_exec_command", timeout_cleanup)
+
+        with pytest.raises(RuntimeError, match="Validation cleanup failed"):
+            gpu_validation._run_x86_case(config=config, case=case)
 
     def test_exec_command_applies_orchestration_timeout(
         self,

--- a/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import importlib.util
 import subprocess
 import sys
@@ -76,6 +77,7 @@ class TestGpuValidationCommand:
                 case.architecture,
                 case.cuda_major,
                 case.server_image,
+                case.test_environment,
             )
             for case in gpu_validation._GPU_VALIDATION_CASES
         ] == [
@@ -85,6 +87,7 @@ class TestGpuValidationCommand:
                 "x86_64",
                 "12",
                 None,
+                (),
             ),
             (
                 "x86_64-cuda13-gpu",
@@ -92,6 +95,7 @@ class TestGpuValidationCommand:
                 "x86_64",
                 "13",
                 None,
+                (),
             ),
             (
                 "aarch64-cuda12-gpu",
@@ -99,6 +103,7 @@ class TestGpuValidationCommand:
                 "aarch64",
                 "12",
                 "ghcr.io/lupinemachines/lupine-server@sha256:e6b1103392165e929ca7f4f910eeec9f0b0f7155c5ff65b7402ca083c6bf9d53",
+                (("TMS_TEST_LUPINE", "1"),),
             ),
             (
                 "aarch64-cuda13-gpu",
@@ -106,6 +111,7 @@ class TestGpuValidationCommand:
                 "aarch64",
                 "13",
                 "ghcr.io/lupinemachines/lupine-server@sha256:f1d805e14e0b2da5d5912adeed72f3e1c7d0458082c3cbaf3ba9bb2346b869cd",
+                (("TMS_TEST_LUPINE", "1"),),
             ),
         ]
 
@@ -135,23 +141,34 @@ class TestGpuValidationCommand:
         assert "/workspace/scripts" not in script
         assert "test_merge_cuda_wheels.py" not in script
 
-    def test_x86_script_runs_every_runtime_test(self) -> None:
-        """Direct NVIDIA validation does not exclude any runtime test."""
+    def test_gpu_scripts_do_not_deselect_runtime_tests(self) -> None:
+        """Runtime-specific skips remain visible in pytest output."""
 
         assert "--deselect" not in gpu_validation._X86_VALIDATION_SCRIPT
+        assert "--deselect" not in gpu_validation._ARM_VALIDATION_SCRIPT
 
-    def test_arm_script_excludes_only_lupine_incompatible_tests(self) -> None:
-        """Lupine omits only tests invalidated by its host-memory emulation."""
+    def test_lupine_runtime_tests_declare_exact_skip_markers(self) -> None:
+        """Only the two host-memory tests opt out under Lupine."""
 
-        script = gpu_validation._ARM_VALIDATION_SCRIPT
+        test_path = Path(__file__).parents[4] / "test" / "test_examples.py"
+        source = test_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        marked_tests = {
+            node.name
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and any(
+                isinstance(decorator, ast.Name)
+                and decorator.id == "_skip_on_lupine"
+                for decorator in node.decorator_list
+            )
+        }
 
-        assert script.count("--deselect") == 3
-        assert (
-            "--deselect 'test/test_examples.py::test_cpu_backup_preload_backend_from_env'"
-            in script
-        )
-        assert "--deselect 'test/test_examples.py::test_disk_backup[preload]'" in script
-        assert "--deselect 'test/test_examples.py::test_disk_backup[torch]'" in script
+        assert 'os.environ.get("TMS_TEST_LUPINE") == "1"' in source
+        assert marked_tests == {
+            "test_cpu_backup_preload_backend_from_env",
+            "test_disk_backup",
+        }
 
     def test_arm_script_requires_real_aarch64_gpu_execution(self) -> None:
         """The ARM gate proves architecture, CUDA major, ELF type, and GPU access."""
@@ -324,6 +341,7 @@ class TestGpuValidationCommand:
         ]
         assert f"{config.release_root}:/workspace:ro" in run_command
         assert f"TMS_CUDA_MAJOR={case.cuda_major}" in run_command
+        assert "TMS_TEST_LUPINE=1" not in run_command
         assert commands[1][0][:4] == ["docker", "image", "inspect", case.image]
         assert "org.opencontainers.image.revision" in commands[1][0][-1]
         assert commands[-1][0][:4] == ["docker", "container", "rm", "--force"]
@@ -440,6 +458,7 @@ class TestGpuValidationCommand:
         assert f"{config.release_root}:/workspace:ro" not in client_commands[0]
         assert f"{config.release_root}:/workspace:ro" in client_commands[1]
         assert f"TMS_CUDA_MAJOR={case.cuda_major}" in client_commands[1]
+        assert "TMS_TEST_LUPINE=1" in client_commands[1]
         assert "http_proxy=http://host.docker.internal:7890" in client_commands[1]
         assert "https_proxy=http://host.docker.internal:7890" in client_commands[1]
         assert client_commands[0][-4] == case.image

--- a/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
@@ -626,6 +626,73 @@ class TestGpuValidationCommand:
         )
 
         assert captured_timeouts == [gpu_validation._COMMAND_TIMEOUT_SECONDS]
+        assert (tmp_path / "command.log").read_text(encoding="utf-8") == (
+            "EXEC: docker info\nRESULT: returncode=0\n"
+        )
+
+    def test_exec_command_logs_nonzero_result_before_raising(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed command records its return code before propagating."""
+
+        def fail_run(
+            command: list[str],
+            *,
+            check: bool,
+            stdout: object,
+            stderr: int,
+            text: bool,
+            timeout: float | None,
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=command, returncode=17)
+
+        monkeypatch.setattr(gpu_validation.subprocess, "run", fail_run)
+        log_path = tmp_path / "command.log"
+
+        with pytest.raises(subprocess.CalledProcessError):
+            gpu_validation._exec_command(
+                command=["docker", "info"],
+                log_path=log_path,
+            )
+
+        assert log_path.read_text(encoding="utf-8") == (
+            "EXEC: docker info\nRESULT: returncode=17\n"
+        )
+
+    def test_exec_command_logs_timeout_before_raising(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A timed-out command records the terminal result before propagating."""
+
+        def timeout_run(
+            command: list[str],
+            *,
+            check: bool,
+            stdout: object,
+            stderr: int,
+            text: bool,
+            timeout: float | None,
+        ) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(command, timeout=timeout)
+
+        monkeypatch.setattr(gpu_validation.subprocess, "run", timeout_run)
+        log_path = tmp_path / "command.log"
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            gpu_validation._exec_command(
+                command=["docker", "info"],
+                log_path=log_path,
+            )
+
+        expected_log: str = (
+            "EXEC: docker info\n"
+            f"RESULT: timeout={gpu_validation._COMMAND_TIMEOUT_SECONDS} seconds\n"
+        )
+        assert log_path.read_text(encoding="utf-8") == expected_log
 
     def test_best_effort_image_inspect_suppresses_timeout(
         self,

--- a/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
+++ b/.claude/skills/tms-publish-release/scripts/test_gpu_validation.py
@@ -150,9 +150,7 @@ class TestGpuValidationCommand:
             "--deselect 'test/test_examples.py::test_cpu_backup_preload_backend_from_env'"
             in script
         )
-        assert (
-            "--deselect 'test/test_examples.py::test_disk_backup[preload]'" in script
-        )
+        assert "--deselect 'test/test_examples.py::test_disk_backup[preload]'" in script
         assert "--deselect 'test/test_examples.py::test_disk_backup[torch]'" in script
 
     def test_arm_script_requires_real_aarch64_gpu_execution(self) -> None:

--- a/.claude/skills/tms-publish-release/scripts/test_release_checks.py
+++ b/.claude/skills/tms-publish-release/scripts/test_release_checks.py
@@ -342,6 +342,138 @@ class TestCommandLogging:
         )
 
 
+class TestPreUpload:
+    def test_pre_upload_cli_dispatches_the_complete_gate(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The public pre-upload command accepts every evidence boundary input."""
+
+        dist_dir = tmp_path / "dist"
+        dist_dir.mkdir()
+        manifest = tmp_path / "artifacts.sha256"
+        manifest.touch()
+        calls: list[dict[str, object]] = []
+        monkeypatch.setattr(
+            release_checks,
+            "run_pre_upload_checks",
+            lambda **kwargs: calls.append(kwargs),
+        )
+
+        result = cli_runner.invoke(
+            release_checks.app,
+            [
+                "pre-upload",
+                "--dist-dir",
+                str(dist_dir),
+                "--manifest",
+                str(manifest),
+                "--expected-version",
+                "0.0.10b1",
+                "--log-path",
+                str(tmp_path / "publish-recheck.log"),
+                "--repo-root",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert len(calls) == 1
+        assert calls[0]["expected_version"] == "0.0.10b1"
+        assert calls[0]["dist_dir"] == dist_dir
+        assert calls[0]["manifest"] == manifest
+
+    def test_one_command_runs_every_pre_upload_gate(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The combined gate checks source, artifacts, Twine, and namespaces."""
+
+        dist_dir = tmp_path / "dist"
+        dist_dir.mkdir()
+        _write_release_artifacts(dist_dir=dist_dir, version="0.0.10b1")
+        repo_root = tmp_path / "repo"
+        _write_repo_source(repo_root=repo_root, version="0.0.10b1")
+        manifest = tmp_path / "artifacts.sha256"
+        release_checks.write_sha256_manifest(dist_dir=dist_dir, output=manifest)
+        commands: list[list[str]] = []
+
+        def complete_command(*, command: list[str], log_path: Path) -> int:
+            commands.append(command)
+            return 0
+
+        monkeypatch.setattr(release_checks, "run_logged_command", complete_command)
+        monkeypatch.setattr(
+            release_checks,
+            "find_publish_collisions",
+            lambda *, version, remote, repository: [],
+        )
+        log_path = tmp_path / "publish-recheck.log"
+
+        release_checks.run_pre_upload_checks(
+            dist_dir=dist_dir,
+            manifest=manifest,
+            expected_version="0.0.10b1",
+            log_path=log_path,
+            repo_root=repo_root,
+            remote="origin",
+            repository="fzyzcjy/torch_memory_saver",
+        )
+
+        assert commands[0][:2] == ["bash", "-lc"]
+        assert commands[0][2].startswith("set -euxo pipefail\n")
+        assert commands[1][:4] == [sys.executable, "-m", "twine", "check"]
+        evidence = log_path.read_text(encoding="utf-8")
+        assert "release_checks version" in evidence
+        assert "release_checks verify-manifest" in evidence
+        assert "release_checks artifacts" in evidence
+        assert "release_checks publish-preflight" in evidence
+        assert evidence.count("RESULT: returncode=0") == 4
+
+    def test_pre_upload_namespace_collision_is_logged(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A late namespace collision fails closed with complete evidence."""
+
+        dist_dir = tmp_path / "dist"
+        dist_dir.mkdir()
+        _write_release_artifacts(dist_dir=dist_dir, version="0.0.10b1")
+        repo_root = tmp_path / "repo"
+        _write_repo_source(repo_root=repo_root, version="0.0.10b1")
+        manifest = tmp_path / "artifacts.sha256"
+        release_checks.write_sha256_manifest(dist_dir=dist_dir, output=manifest)
+        monkeypatch.setattr(
+            release_checks,
+            "run_logged_command",
+            lambda *, command, log_path: 0,
+        )
+        monkeypatch.setattr(
+            release_checks,
+            "find_publish_collisions",
+            lambda *, version, remote, repository: ["PyPI version 0.0.10b1"],
+        )
+        log_path = tmp_path / "publish-recheck.log"
+
+        with pytest.raises(ValueError, match="Release identity already exists"):
+            release_checks.run_pre_upload_checks(
+                dist_dir=dist_dir,
+                manifest=manifest,
+                expected_version="0.0.10b1",
+                log_path=log_path,
+                repo_root=repo_root,
+                remote="origin",
+                repository="fzyzcjy/torch_memory_saver",
+            )
+
+        evidence = log_path.read_text(encoding="utf-8")
+        assert "Traceback" in evidence
+        assert "RESULT: error=ValueError" in evidence
+
+
 class TestArtifactValidation:
     def test_complete_release_artifact_set_is_accepted(self, tmp_path: Path) -> None:
         """Both architecture wheels and the sdist satisfy the release gate."""
@@ -619,6 +751,18 @@ def _write_release_artifacts(
         repo_root=dist_dir,
         omitted_source=omitted_source,
     )
+
+
+def _write_repo_source(*, repo_root: Path, version: str) -> None:
+    repo_root.mkdir()
+    (repo_root / "setup.py").write_text(
+        f'from setuptools import setup\nsetup(version="{version}")\n',
+        encoding="utf-8",
+    )
+    csrc_dir = repo_root / "csrc"
+    csrc_dir.mkdir()
+    for source_name in ("core.cpp", "core.h", "hardware_xpu_support.cpp"):
+        (csrc_dir / source_name).write_text(source_name, encoding="utf-8")
 
 
 def _write_wheel(*, wheel_path: Path, version: str, architecture: str) -> None:

--- a/.claude/skills/tms-publish-release/scripts/test_release_checks.py
+++ b/.claude/skills/tms-publish-release/scripts/test_release_checks.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import base64
+import csv
+import hashlib
 import importlib.util
+import subprocess
 import sys
 import tarfile
 import zipfile
-from io import BytesIO
+from io import BytesIO, StringIO
 from pathlib import Path
 from types import ModuleType
 from urllib.error import HTTPError
@@ -252,6 +256,92 @@ class TestPublishPreflight:
         )
 
 
+class TestCommandLogging:
+    def test_run_command_records_command_output_and_result(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Evidence logging preserves command output and terminal status."""
+
+        def complete_run(
+            command: list[str],
+            *,
+            check: bool,
+            stdout: object,
+            stderr: int,
+            text: bool,
+            timeout: float | None,
+        ) -> subprocess.CompletedProcess[str]:
+            stdout.write("command output\n")
+            return subprocess.CompletedProcess(args=command, returncode=0)
+
+        monkeypatch.setattr(release_checks.subprocess, "run", complete_run)
+        log_path = tmp_path / "evidence.log"
+
+        result = cli_runner.invoke(
+            release_checks.app,
+            ["run", "--log-path", str(log_path), "--", "example", "--flag"],
+        )
+
+        assert result.exit_code == 0
+        assert log_path.read_text(encoding="utf-8") == (
+            "EXEC: example --flag\ncommand output\nRESULT: returncode=0\n"
+        )
+
+    def test_run_command_propagates_nonzero_result(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed evidence command keeps its return code and stops the workflow."""
+
+        def fail_run(
+            command: list[str],
+            *,
+            check: bool,
+            stdout: object,
+            stderr: int,
+            text: bool,
+            timeout: float | None,
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=command, returncode=19)
+
+        monkeypatch.setattr(release_checks.subprocess, "run", fail_run)
+        log_path = tmp_path / "evidence.log"
+
+        result = cli_runner.invoke(
+            release_checks.app,
+            ["run", "--log-path", str(log_path), "--", "example"],
+        )
+
+        assert result.exit_code == 19
+        assert log_path.read_text(encoding="utf-8").endswith("RESULT: returncode=19\n")
+
+    def test_run_command_records_timeout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A timed-out evidence command leaves a terminal timeout record."""
+
+        def timeout_run(
+            *args: object, **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(cmd=["example"], timeout=7)
+
+        monkeypatch.setattr(release_checks.subprocess, "run", timeout_run)
+        log_path = tmp_path / "evidence.log"
+
+        result = cli_runner.invoke(
+            release_checks.app,
+            ["run", "--log-path", str(log_path), "--", "example"],
+        )
+
+        assert result.exit_code != 0
+        assert log_path.read_text(encoding="utf-8").endswith(
+            "RESULT: timeout=7 seconds\n"
+        )
+
+
 class TestArtifactValidation:
     def test_complete_release_artifact_set_is_accepted(self, tmp_path: Path) -> None:
         """Both architecture wheels and the sdist satisfy the release gate."""
@@ -355,6 +445,137 @@ class TestArtifactValidation:
                 repo_root=tmp_path,
             )
 
+    def test_missing_wheel_record_is_rejected(self, tmp_path: Path) -> None:
+        """A wheel without RECORD cannot pass the artifact gate."""
+
+        _write_release_artifacts(dist_dir=tmp_path, version="0.0.10b1")
+        wheel_path = (
+            tmp_path / "torch_memory_saver-0.0.10b1-cp39-abi3-manylinux2014_x86_64.whl"
+        )
+        _rewrite_wheel_without_record_update(
+            wheel_path=wheel_path,
+            removed_suffix=".dist-info/RECORD",
+        )
+
+        with pytest.raises(ValueError, match="exactly one file ending.*RECORD"):
+            release_checks.validate_release_artifacts(
+                dist_dir=tmp_path,
+                expected_version="0.0.10b1",
+                repo_root=tmp_path,
+            )
+
+    @pytest.mark.parametrize("field", ["hash", "size"])
+    def test_corrupt_wheel_record_entry_is_rejected(
+        self,
+        field: str,
+        tmp_path: Path,
+    ) -> None:
+        """A stale RECORD hash or size cannot pass the artifact gate."""
+
+        _write_release_artifacts(dist_dir=tmp_path, version="0.0.10b1")
+        wheel_path = (
+            tmp_path / "torch_memory_saver-0.0.10b1-cp39-abi3-manylinux2014_x86_64.whl"
+        )
+        _corrupt_wheel_record(wheel_path=wheel_path, field=field)
+
+        with pytest.raises(ValueError, match=f"RECORD {field} mismatch"):
+            release_checks.validate_release_artifacts(
+                dist_dir=tmp_path,
+                expected_version="0.0.10b1",
+                repo_root=tmp_path,
+            )
+
+    @pytest.mark.parametrize(
+        ("corruption", "message"),
+        [
+            ("duplicate", "Duplicate RECORD path"),
+            ("missing", "RECORD member set mismatch"),
+            ("self", "RECORD self-entry must omit hash and size"),
+        ],
+    )
+    def test_invalid_wheel_record_structure_is_rejected(
+        self,
+        corruption: str,
+        message: str,
+        tmp_path: Path,
+    ) -> None:
+        """RECORD must map each wheel member exactly once with an empty self-entry."""
+
+        _write_release_artifacts(dist_dir=tmp_path, version="0.0.10b1")
+        wheel_path = (
+            tmp_path / "torch_memory_saver-0.0.10b1-cp39-abi3-manylinux2014_x86_64.whl"
+        )
+        _corrupt_wheel_record(wheel_path=wheel_path, field=corruption)
+
+        with pytest.raises(ValueError, match=message):
+            release_checks.validate_release_artifacts(
+                dist_dir=tmp_path,
+                expected_version="0.0.10b1",
+                repo_root=tmp_path,
+            )
+
+    def test_sha256_manifest_rejects_artifact_changed_after_review(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The publish recheck rejects an artifact changed after human review."""
+
+        dist_dir = tmp_path / "dist"
+        dist_dir.mkdir()
+        artifact_path = dist_dir / "artifact.whl"
+        artifact_path.write_bytes(b"approved")
+        manifest = tmp_path / "artifacts.sha256"
+        release_checks.write_sha256_manifest(dist_dir=dist_dir, output=manifest)
+
+        release_checks.verify_sha256_manifest(
+            dist_dir=dist_dir,
+            manifest=manifest,
+        )
+        artifact_path.write_bytes(b"replaced")
+
+        with pytest.raises(ValueError, match="SHA-256 mismatch"):
+            release_checks.verify_sha256_manifest(
+                dist_dir=dist_dir,
+                manifest=manifest,
+            )
+
+    @pytest.mark.parametrize("change", ["add", "remove"])
+    def test_sha256_manifest_rejects_artifact_set_changes(
+        self,
+        change: str,
+        tmp_path: Path,
+    ) -> None:
+        """The approved manifest covers the exact final artifact filename set."""
+
+        dist_dir = tmp_path / "dist"
+        dist_dir.mkdir()
+        artifact_path = dist_dir / "artifact.whl"
+        artifact_path.write_bytes(b"approved")
+        manifest = tmp_path / "artifacts.sha256"
+        release_checks.write_sha256_manifest(dist_dir=dist_dir, output=manifest)
+        if change == "add":
+            (dist_dir / "unexpected.tar.gz").write_bytes(b"unexpected")
+        else:
+            artifact_path.unlink()
+
+        with pytest.raises(ValueError, match="manifest artifact set mismatch"):
+            release_checks.verify_sha256_manifest(
+                dist_dir=dist_dir,
+                manifest=manifest,
+            )
+
+    def test_sha256_manifest_cannot_be_overwritten(self, tmp_path: Path) -> None:
+        """A reviewed manifest cannot be silently regenerated in place."""
+
+        dist_dir = tmp_path / "dist"
+        dist_dir.mkdir()
+        (dist_dir / "artifact.whl").write_bytes(b"approved")
+        manifest = tmp_path / "artifacts.sha256"
+        release_checks.write_sha256_manifest(dist_dir=dist_dir, output=manifest)
+
+        with pytest.raises(ValueError, match="Refusing to overwrite"):
+            release_checks.write_sha256_manifest(dist_dir=dist_dir, output=manifest)
+
     def test_missing_backend_source_is_rejected(self, tmp_path: Path) -> None:
         """An sdist missing a platform backend source cannot pass validation."""
 
@@ -402,17 +623,23 @@ def _write_release_artifacts(
 
 def _write_wheel(*, wheel_path: Path, version: str, architecture: str) -> None:
     metadata_root = f"torch_memory_saver-{version}.dist-info"
-    with zipfile.ZipFile(wheel_path, mode="w") as wheel:
-        wheel.writestr(
-            f"{metadata_root}/METADATA",
-            f"Name: torch-memory-saver\nVersion: {version}\n",
-        )
-        wheel.writestr(
-            f"{metadata_root}/WHEEL",
-            f"Wheel-Version: 1.0\nTag: cp39-abi3-manylinux2014_{architecture}\n",
-        )
-        for binary_name in release_checks._EXPECTED_BINARY_NAMES:
-            wheel.writestr(binary_name, _elf_header(architecture=architecture))
+    contents = {
+        f"{metadata_root}/METADATA": (
+            f"Name: torch-memory-saver\nVersion: {version}\n"
+        ).encode(),
+        f"{metadata_root}/WHEEL": (
+            f"Wheel-Version: 1.0\nTag: cp39-abi3-manylinux2014_{architecture}\n"
+        ).encode(),
+        **{
+            binary_name: _elf_header(architecture=architecture)
+            for binary_name in release_checks._EXPECTED_BINARY_NAMES
+        },
+    }
+    _write_wheel_contents(
+        wheel_path=wheel_path,
+        contents=contents,
+        record_name=f"{metadata_root}/RECORD",
+    )
 
 
 def _write_sdist(
@@ -442,21 +669,101 @@ def _write_sdist(
 
 def _rewrite_wheel_without(*, wheel_path: Path, removed_name: str) -> None:
     with zipfile.ZipFile(wheel_path) as wheel:
+        record_name = next(
+            name for name in wheel.namelist() if name.endswith(".dist-info/RECORD")
+        )
         contents = {
-            name: wheel.read(name) for name in wheel.namelist() if name != removed_name
+            name: wheel.read(name)
+            for name in wheel.namelist()
+            if name not in {removed_name, record_name}
+        }
+    _write_wheel_contents(
+        wheel_path=wheel_path,
+        contents=contents,
+        record_name=record_name,
+    )
+
+
+def _rewrite_wheel_file(*, wheel_path: Path, target_name: str, content: bytes) -> None:
+    with zipfile.ZipFile(wheel_path) as wheel:
+        record_name = next(
+            name for name in wheel.namelist() if name.endswith(".dist-info/RECORD")
+        )
+        contents = {
+            name: wheel.read(name) for name in wheel.namelist() if name != record_name
+        }
+    contents[target_name] = content
+    _write_wheel_contents(
+        wheel_path=wheel_path,
+        contents=contents,
+        record_name=record_name,
+    )
+
+
+def _write_wheel_contents(
+    *,
+    wheel_path: Path,
+    contents: dict[str, bytes],
+    record_name: str,
+) -> None:
+    record_output = StringIO()
+    writer = csv.writer(record_output, lineterminator="\n")
+    for name, content in sorted(contents.items()):
+        digest = (
+            base64.urlsafe_b64encode(hashlib.sha256(content).digest())
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        writer.writerow((name, f"sha256={digest}", str(len(content))))
+    writer.writerow((record_name, "", ""))
+
+    with zipfile.ZipFile(wheel_path, mode="w") as wheel:
+        for name, content in contents.items():
+            wheel.writestr(name, content)
+        wheel.writestr(record_name, record_output.getvalue())
+
+
+def _rewrite_wheel_without_record_update(
+    *,
+    wheel_path: Path,
+    removed_suffix: str,
+) -> None:
+    with zipfile.ZipFile(wheel_path) as wheel:
+        contents = {
+            name: wheel.read(name)
+            for name in wheel.namelist()
+            if not name.endswith(removed_suffix)
         }
     with zipfile.ZipFile(wheel_path, mode="w") as wheel:
         for name, content in contents.items():
             wheel.writestr(name, content)
 
 
-def _rewrite_wheel_file(*, wheel_path: Path, target_name: str, content: bytes) -> None:
+def _corrupt_wheel_record(*, wheel_path: Path, field: str) -> None:
     with zipfile.ZipFile(wheel_path) as wheel:
         contents = {name: wheel.read(name) for name in wheel.namelist()}
-    contents[target_name] = content
+        record_name = next(
+            name for name in contents if name.endswith(".dist-info/RECORD")
+        )
+    rows = list(csv.reader(StringIO(contents[record_name].decode())))
+    target_row = next(row for row in rows if row[0].endswith(".dist-info/WHEEL"))
+    if field in {"hash", "size"}:
+        target_row[1 if field == "hash" else 2] = "broken"
+    elif field == "duplicate":
+        rows.append(target_row.copy())
+    elif field == "missing":
+        rows.remove(target_row)
+    elif field == "self":
+        next(row for row in rows if row[0] == record_name)[1] = "sha256=broken"
+    else:
+        raise ValueError(f"Unknown RECORD corruption: {field}")
+    record_output = StringIO()
+    csv.writer(record_output, lineterminator="\n").writerows(rows)
+    contents[record_name] = record_output.getvalue().encode()
+
     with zipfile.ZipFile(wheel_path, mode="w") as wheel:
-        for name, existing_content in contents.items():
-            wheel.writestr(name, existing_content)
+        for name, content in contents.items():
+            wheel.writestr(name, content)
 
 
 def _elf_header(*, architecture: str) -> bytes:

--- a/.claude/skills/tms-publish-release/scripts/test_release_checks.py
+++ b/.claude/skills/tms-publish-release/scripts/test_release_checks.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tarfile
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from types import ModuleType
+from urllib.error import HTTPError
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _load_release_checks_module() -> ModuleType:
+    module_path = Path(__file__).with_name("release_checks.py")
+    spec = importlib.util.spec_from_file_location("release_checks", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+release_checks = _load_release_checks_module()
+cli_runner = CliRunner()
+
+
+class TestVersionValidation:
+    def test_version_command_validates_setup_version(self, tmp_path: Path) -> None:
+        """The Typer command validates a matching canonical setup.py version."""
+
+        setup_py = tmp_path / "setup.py"
+        setup_py.write_text(
+            "from setuptools import setup\nsetup(name='example', version='0.0.10b1')\n"
+        )
+
+        result = cli_runner.invoke(
+            release_checks.app,
+            [
+                "version",
+                "--setup-py",
+                str(setup_py),
+                "--expected-version",
+                "0.0.10b1",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert result.stdout == "Validated canonical setup.py version: 0.0.10b1\n"
+
+    def test_canonical_beta_is_accepted(self) -> None:
+        """Canonical compact beta versions are accepted."""
+
+        release_checks.validate_canonical_version(version="0.0.10b1")
+
+    @pytest.mark.parametrize(
+        "version",
+        ["0.0.10.beta-1", "0.0.10beta1", "0.0.10-b1", "v0.0.10b1"],
+    )
+    def test_noncanonical_beta_spellings_are_rejected(self, version: str) -> None:
+        """Alternative beta spellings are rejected before artifact creation."""
+
+        with pytest.raises(ValueError, match="not canonical"):
+            release_checks.validate_canonical_version(version=version)
+
+    def test_setup_version_reads_literal_keyword(self, tmp_path: Path) -> None:
+        """The setup.py version is read without importing build configuration."""
+
+        setup_py = tmp_path / "setup.py"
+        setup_py.write_text(
+            "from setuptools import setup\nsetup(name='example', version='0.0.10b1')\n"
+        )
+
+        assert release_checks.read_setup_version(setup_py=setup_py) == "0.0.10b1"
+
+
+class TestPyPIVersionValidation:
+    def test_pypi_command_accepts_unpublished_version(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing PyPI release is accepted as available for publication."""
+
+        def raise_not_found(url: str, *, timeout: int) -> None:
+            assert url.endswith("/torch-memory-saver/0.0.10b1/json")
+            assert timeout == 20
+            raise HTTPError(url=url, code=404, msg="Not Found", hdrs=None, fp=None)
+
+        monkeypatch.setattr(release_checks, "urlopen", raise_not_found)
+
+        result = cli_runner.invoke(
+            release_checks.app,
+            ["pypi", "--expected-version", "0.0.10b1"],
+        )
+
+        assert result.exit_code == 0
+        assert result.stdout == "Confirmed PyPI version is available: 0.0.10b1\n"
+
+    def test_pypi_command_rejects_published_version(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An existing PyPI release is rejected before artifacts are built."""
+
+        monkeypatch.setattr(
+            release_checks,
+            "urlopen",
+            lambda url, *, timeout: BytesIO(b"{}"),
+        )
+
+        result = cli_runner.invoke(
+            release_checks.app,
+            ["pypi", "--expected-version", "0.0.10b1"],
+        )
+
+        assert result.exit_code == 2
+        assert result.exception is not None
+        assert result.exception.__context__ is not None
+        assert "already exists on PyPI" in str(result.exception.__context__)
+
+    def test_pypi_network_failure_is_reported_without_secondary_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A namespace lookup failure remains an actionable CLI error."""
+
+        def fail_lookup(*, version: str) -> bool:
+            raise RuntimeError("PyPI unavailable")
+
+        monkeypatch.setattr(release_checks, "pypi_version_exists", fail_lookup)
+
+        result = cli_runner.invoke(
+            release_checks.app,
+            ["pypi", "--expected-version", "0.0.10b1"],
+        )
+
+        assert result.exit_code == 1
+        assert isinstance(result.exception, release_checks.click.ClickException)
+        assert "PyPI unavailable" in str(result.exception)
+        assert "AttributeError" not in str(result.exception)
+
+
+class TestPublishPreflight:
+    def test_publish_preflight_accepts_unused_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Publication can proceed only when all three namespaces are unused."""
+
+        monkeypatch.setattr(
+            release_checks,
+            "find_publish_collisions",
+            lambda *, version, remote, repository: [],
+        )
+
+        result = cli_runner.invoke(
+            release_checks.app,
+            ["publish-preflight", "--expected-version", "0.0.10b1"],
+        )
+
+        assert result.exit_code == 0
+        assert "PyPI, origin, and GitHub: 0.0.10b1" in result.stdout
+
+    def test_publish_preflight_reports_every_existing_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Any existing package, tag, or release blocks publication."""
+
+        monkeypatch.setattr(
+            release_checks,
+            "pypi_version_exists",
+            lambda *, version: True,
+        )
+        monkeypatch.setattr(
+            release_checks,
+            "remote_tag_exists",
+            lambda *, version, remote: True,
+        )
+        monkeypatch.setattr(
+            release_checks,
+            "github_release_exists",
+            lambda *, version, repository: True,
+        )
+
+        result = cli_runner.invoke(
+            release_checks.app,
+            ["publish-preflight", "--expected-version", "0.0.10b1"],
+        )
+
+        assert result.exit_code == 2
+        assert result.exception is not None
+        assert result.exception.__context__ is not None
+        message = str(result.exception.__context__)
+        assert "PyPI version 0.0.10b1" in message
+        assert "origin tag v0.0.10b1" in message
+        assert "GitHub Release v0.0.10b1" in message
+
+    @pytest.mark.parametrize(
+        ("returncode", "expected"),
+        [(0, True), (2, False)],
+    )
+    def test_remote_tag_exit_codes_are_classified(
+        self,
+        returncode: int,
+        expected: bool,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Git distinguishes an existing tag from an absent remote ref."""
+
+        monkeypatch.setattr(
+            release_checks,
+            "_exec_command",
+            lambda *, command: release_checks.CommandResult(
+                returncode=returncode,
+                stdout="",
+                stderr="",
+            ),
+        )
+
+        assert (
+            release_checks.remote_tag_exists(version="0.0.10b1", remote="origin")
+            is expected
+        )
+
+    @pytest.mark.parametrize(
+        ("returncode", "stderr", "expected"),
+        [(0, "", True), (1, "gh: Not Found (HTTP 404)", False)],
+    )
+    def test_github_release_exit_codes_are_classified(
+        self,
+        returncode: int,
+        stderr: str,
+        expected: bool,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """GitHub distinguishes an existing release from an absent tag release."""
+
+        monkeypatch.setattr(
+            release_checks,
+            "_exec_command",
+            lambda *, command: release_checks.CommandResult(
+                returncode=returncode,
+                stdout="",
+                stderr=stderr,
+            ),
+        )
+
+        assert (
+            release_checks.github_release_exists(
+                version="0.0.10b1", repository="fzyzcjy/torch_memory_saver"
+            )
+            is expected
+        )
+
+
+class TestArtifactValidation:
+    def test_complete_release_artifact_set_is_accepted(self, tmp_path: Path) -> None:
+        """Both architecture wheels and the sdist satisfy the release gate."""
+
+        _write_release_artifacts(dist_dir=tmp_path, version="0.0.10b1")
+
+        release_checks.validate_release_artifacts(
+            dist_dir=tmp_path,
+            expected_version="0.0.10b1",
+            repo_root=tmp_path,
+        )
+
+    def test_missing_architecture_wheel_is_rejected(self, tmp_path: Path) -> None:
+        """A release cannot pass without its aarch64 wheel."""
+
+        _write_release_artifacts(dist_dir=tmp_path, version="0.0.10b1")
+        (
+            tmp_path / "torch_memory_saver-0.0.10b1-cp39-abi3-manylinux2014_aarch64.whl"
+        ).unlink()
+
+        with pytest.raises(ValueError, match="missing=.*aarch64"):
+            release_checks.validate_release_artifacts(
+                dist_dir=tmp_path,
+                expected_version="0.0.10b1",
+                repo_root=tmp_path,
+            )
+
+    def test_unexpected_stale_artifact_is_rejected(self, tmp_path: Path) -> None:
+        """Stale distributions cannot be included in a release upload."""
+
+        _write_release_artifacts(dist_dir=tmp_path, version="0.0.10b1")
+        (tmp_path / "torch_memory_saver-0.0.9.tar.gz").touch()
+
+        with pytest.raises(ValueError, match="unexpected=.*0.0.9"):
+            release_checks.validate_release_artifacts(
+                dist_dir=tmp_path,
+                expected_version="0.0.10b1",
+                repo_root=tmp_path,
+            )
+
+    def test_missing_cuda_binary_is_rejected(self, tmp_path: Path) -> None:
+        """A wheel missing a CUDA runtime variant cannot pass validation."""
+
+        _write_release_artifacts(dist_dir=tmp_path, version="0.0.10b1")
+        wheel_path = (
+            tmp_path / "torch_memory_saver-0.0.10b1-cp39-abi3-manylinux2014_x86_64.whl"
+        )
+        _rewrite_wheel_without(
+            wheel_path=wheel_path,
+            removed_name="torch_memory_saver_hook_mode_torch_cu13.abi3.so",
+        )
+
+        with pytest.raises(
+            ValueError, match="missing=.*torch_memory_saver_hook_mode_torch_cu13"
+        ):
+            release_checks.validate_release_artifacts(
+                dist_dir=tmp_path,
+                expected_version="0.0.10b1",
+                repo_root=tmp_path,
+            )
+
+    def test_mislabeled_binary_architecture_is_rejected(self, tmp_path: Path) -> None:
+        """A wheel tag cannot disagree with the architecture of its ELF binaries."""
+
+        _write_release_artifacts(dist_dir=tmp_path, version="0.0.10b1")
+        wheel_path = (
+            tmp_path / "torch_memory_saver-0.0.10b1-cp39-abi3-manylinux2014_aarch64.whl"
+        )
+        _rewrite_wheel_file(
+            wheel_path=wheel_path,
+            target_name="torch_memory_saver_hook_mode_torch_cu13.abi3.so",
+            content=_elf_header(architecture="x86_64"),
+        )
+
+        with pytest.raises(
+            ValueError, match="ELF machine mismatch.*expected 183, found 62"
+        ):
+            release_checks.validate_release_artifacts(
+                dist_dir=tmp_path,
+                expected_version="0.0.10b1",
+                repo_root=tmp_path,
+            )
+
+    def test_unsuffixed_binary_must_equal_cuda12_binary(self, tmp_path: Path) -> None:
+        """The historical preload name remains a byte-identical CUDA 12 alias."""
+
+        _write_release_artifacts(dist_dir=tmp_path, version="0.0.10b1")
+        wheel_path = (
+            tmp_path / "torch_memory_saver-0.0.10b1-cp39-abi3-manylinux2014_x86_64.whl"
+        )
+        _rewrite_wheel_file(
+            wheel_path=wheel_path,
+            target_name="torch_memory_saver_hook_mode_preload.abi3.so",
+            content=_elf_header(architecture="x86_64") + b"different",
+        )
+
+        with pytest.raises(ValueError, match="compatibility binary differs"):
+            release_checks.validate_release_artifacts(
+                dist_dir=tmp_path,
+                expected_version="0.0.10b1",
+                repo_root=tmp_path,
+            )
+
+    def test_missing_backend_source_is_rejected(self, tmp_path: Path) -> None:
+        """An sdist missing a platform backend source cannot pass validation."""
+
+        _write_release_artifacts(
+            dist_dir=tmp_path,
+            version="0.0.10b1",
+            omitted_source="csrc/hardware_xpu_support.cpp",
+        )
+
+        with pytest.raises(
+            ValueError, match="missing backend sources:.*hardware_xpu_support.cpp"
+        ):
+            release_checks.validate_release_artifacts(
+                dist_dir=tmp_path,
+                expected_version="0.0.10b1",
+                repo_root=tmp_path,
+            )
+
+
+def _write_release_artifacts(
+    *,
+    dist_dir: Path,
+    version: str,
+    omitted_source: str | None = None,
+) -> None:
+    csrc_dir = dist_dir / "csrc"
+    csrc_dir.mkdir()
+    for source_name in ("core.cpp", "core.h", "hardware_xpu_support.cpp"):
+        (csrc_dir / source_name).write_text(source_name)
+
+    for architecture in ("x86_64", "aarch64"):
+        _write_wheel(
+            wheel_path=dist_dir
+            / f"torch_memory_saver-{version}-cp39-abi3-manylinux2014_{architecture}.whl",
+            version=version,
+            architecture=architecture,
+        )
+    _write_sdist(
+        sdist_path=dist_dir / f"torch_memory_saver-{version}.tar.gz",
+        version=version,
+        repo_root=dist_dir,
+        omitted_source=omitted_source,
+    )
+
+
+def _write_wheel(*, wheel_path: Path, version: str, architecture: str) -> None:
+    metadata_root = f"torch_memory_saver-{version}.dist-info"
+    with zipfile.ZipFile(wheel_path, mode="w") as wheel:
+        wheel.writestr(
+            f"{metadata_root}/METADATA",
+            f"Name: torch-memory-saver\nVersion: {version}\n",
+        )
+        wheel.writestr(
+            f"{metadata_root}/WHEEL",
+            f"Wheel-Version: 1.0\nTag: cp39-abi3-manylinux2014_{architecture}\n",
+        )
+        for binary_name in release_checks._EXPECTED_BINARY_NAMES:
+            wheel.writestr(binary_name, _elf_header(architecture=architecture))
+
+
+def _write_sdist(
+    *,
+    sdist_path: Path,
+    version: str,
+    repo_root: Path,
+    omitted_source: str | None,
+) -> None:
+    package_info = sdist_path.parent / "PKG-INFO"
+    package_info.write_text(f"Name: torch-memory-saver\nVersion: {version}\n")
+    with tarfile.open(sdist_path, mode="w:gz") as sdist:
+        sdist.add(package_info, arcname=f"torch_memory_saver-{version}/PKG-INFO")
+        sdist.add(
+            package_info,
+            arcname=f"torch_memory_saver-{version}/torch_memory_saver.egg-info/PKG-INFO",
+        )
+        for source_path in sorted((repo_root / "csrc").iterdir()):
+            relative_path = source_path.relative_to(repo_root).as_posix()
+            if relative_path != omitted_source:
+                sdist.add(
+                    source_path,
+                    arcname=f"torch_memory_saver-{version}/{relative_path}",
+                )
+    package_info.unlink()
+
+
+def _rewrite_wheel_without(*, wheel_path: Path, removed_name: str) -> None:
+    with zipfile.ZipFile(wheel_path) as wheel:
+        contents = {
+            name: wheel.read(name) for name in wheel.namelist() if name != removed_name
+        }
+    with zipfile.ZipFile(wheel_path, mode="w") as wheel:
+        for name, content in contents.items():
+            wheel.writestr(name, content)
+
+
+def _rewrite_wheel_file(*, wheel_path: Path, target_name: str, content: bytes) -> None:
+    with zipfile.ZipFile(wheel_path) as wheel:
+        contents = {name: wheel.read(name) for name in wheel.namelist()}
+    contents[target_name] = content
+    with zipfile.ZipFile(wheel_path, mode="w") as wheel:
+        for name, existing_content in contents.items():
+            wheel.writestr(name, existing_content)
+
+
+def _elf_header(*, architecture: str) -> bytes:
+    binary = bytearray(20)
+    binary[:7] = b"\x7fELF\x02\x01\x01"
+    binary[18:20] = release_checks._ELF_MACHINE_BY_ARCHITECTURE[architecture].to_bytes(
+        length=2, byteorder="little"
+    )
+    return bytes(binary)

--- a/.claude/skills/tms-publish-release/scripts/test_verify_published_release.py
+++ b/.claude/skills/tms-publish-release/scripts/test_verify_published_release.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+def test_published_release_script_is_strict_valid_shell() -> None:
+    """The public post-release workflow is strict shell with valid syntax."""
+
+    script_path = Path(__file__).with_name("verify_published_release.sh")
+    source = script_path.read_text(encoding="utf-8")
+
+    subprocess.run(["bash", "-n", str(script_path)], check=True)
+    assert source.startswith("#!/usr/bin/env bash\nset -euxo pipefail\n")
+    assert "bash -lc '\nset -euxo pipefail\n" in source
+
+
+def test_published_release_script_uses_fresh_pypi_installs_and_runtime_tests() -> None:
+    """Both CUDA majors reject preinstallation before exercising PyPI runtime code."""
+
+    source = (
+        Path(__file__)
+        .with_name("verify_published_release.sh")
+        .read_text(encoding="utf-8")
+    )
+
+    assert source.count("docker run --rm --pull missing") == 1
+    assert "cuda12.4-cudnn9-runtime" in source
+    assert "cuda13.0-cudnn9-runtime" in source
+    assert source.index('find_spec("torch_memory_saver") is None') < source.index(
+        '"torch-memory-saver==${TMS_RELEASE_VERSION}"'
+    )
+    assert "site-packages" in source
+    assert "pytest -p pytest_skip_gate test -vv -ra" in source
+    assert '"$REPOSITORY_ROOT/test:/release-tests:ro"' in source
+    assert "/dist/" not in source
+
+
+def test_published_release_script_matches_approved_remote_artifacts() -> None:
+    """Post-release checks bind PyPI and GitHub state to the approved manifest."""
+
+    source = (
+        Path(__file__)
+        .with_name("verify_published_release.sh")
+        .read_text(encoding="utf-8")
+    )
+
+    assert 'test "$(wc -l < "$ARTIFACT_MANIFEST")" -eq 3' in source
+    assert 'test "$(jq ' in source
+    assert ".digests.sha256" in source
+    assert "api.github.com/repos/fzyzcjy/torch_memory_saver/releases/tags" in source
+    assert "'.tag_name'" in source
+    assert "'.prerelease == true'" in source
+    assert "'.prerelease == false'" in source
+    assert 'echo "RESULT: returncode=$status"' in source
+
+
+def test_every_repository_shell_script_enables_strict_mode_first() -> None:
+    """Every shell script enables strict tracing before its first command."""
+
+    repository_root = Path(__file__).parents[4]
+    script_paths = sorted((repository_root / "scripts").glob("*.sh")) + sorted(
+        Path(__file__).parent.glob("*.sh")
+    )
+
+    assert script_paths
+    for script_path in script_paths:
+        lines = script_path.read_text(encoding="utf-8").splitlines()
+        first_command = next(
+            line for line in lines[1:] if line.strip() and not line.startswith("#")
+        )
+        assert first_command == "set -euxo pipefail", script_path
+
+
+def test_every_documented_shell_context_enables_strict_mode() -> None:
+    """Every runnable doc block and nested remote shell enables strict tracing."""
+
+    skill_source = (
+        Path(__file__).parents[1].joinpath("SKILL.md").read_text(encoding="utf-8")
+    )
+    bash_blocks = [
+        section.split("```", 1)[0] for section in skill_source.split("```bash\n")[1:]
+    ]
+
+    assert bash_blocks
+    assert all(block.startswith("set -euxo pipefail\n") for block in bash_blocks)
+    assert len(
+        re.findall(r"ssh tom-workstation [\"']set -euxo pipefail", skill_source)
+    ) == skill_source.count("ssh tom-workstation")
+    assert "zsh -lc 'set -euxo pipefail;" in skill_source

--- a/.claude/skills/tms-publish-release/scripts/verify_published_release.sh
+++ b/.claude/skills/tms-publish-release/scripts/verify_published_release.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+readonly RELEASE_VERSION="${1:?Usage: verify_published_release.sh VERSION ARTIFACT_MANIFEST}"
+readonly ARTIFACT_MANIFEST="${2:?Usage: verify_published_release.sh VERSION ARTIFACT_MANIFEST}"
+readonly REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+readonly PROXY_URL="${TMS_PROXY_URL:-http://127.0.0.1:7890}"
+readonly PYPI_JSON="$(mktemp)"
+readonly GITHUB_JSON="$(mktemp)"
+readonly EXPECTED_PYTEST_SKIPS='{
+  "test/test_examples.py::test_cleanup_failure_injection_xpu": "XPU-specific path",
+  "test/test_examples.py::test_cpu_backup_multi_device_mmap_restore[preload]": "Multi-device test requires at least two devices",
+  "test/test_examples.py::test_cpu_backup_multi_device_mmap_restore[torch]": "Multi-device test requires at least two devices",
+  "test/test_examples.py::test_disable_unsupported_xpu": "XPU-specific path",
+  "test/test_examples.py::test_free_failure_injection_xpu": "XPU-specific path",
+  "test/test_examples.py::test_memory_margin_unsupported_xpu": "XPU-specific path",
+  "test/test_examples.py::test_multi_device[preload]": "Multi-device test requires at least two devices",
+  "test/test_examples.py::test_multi_device[torch]": "Multi-device test requires at least two devices",
+  "test/test_examples.py::test_multi_device_sync_xpu": "XPU-specific path",
+  "test/test_examples.py::test_multi_device_torch_mode": "Multi-device test requires at least two devices",
+  "test/test_examples.py::test_resume_failure_injection_xpu": "XPU-specific path"
+}'
+
+trap 'status=$?; rm -f "$PYPI_JSON" "$GITHUB_JSON"; echo "RESULT: returncode=$status"; exit "$status"' EXIT
+
+test "$(uname -m)" = "x86_64"
+command -v curl jq docker
+test -f "$ARTIFACT_MANIFEST"
+test "$(wc -l < "$ARTIFACT_MANIFEST")" -eq 3
+
+curl --fail --silent --show-error --location --proxy "$PROXY_URL" \
+  "https://pypi.org/pypi/torch-memory-saver/${RELEASE_VERSION}/json" \
+  --output "$PYPI_JSON"
+test "$(jq '.urls | length' "$PYPI_JSON")" -eq 3
+while read -r expected_digest filename; do
+  test "$(jq --raw-output --arg filename "$filename" '.urls[] | select(.filename == $filename) | .digests.sha256' "$PYPI_JSON")" = "$expected_digest"
+done < "$ARTIFACT_MANIFEST"
+
+curl --fail --silent --show-error --location --proxy "$PROXY_URL" \
+  "https://api.github.com/repos/fzyzcjy/torch_memory_saver/releases/tags/v${RELEASE_VERSION}" \
+  --output "$GITHUB_JSON"
+test "$(jq --raw-output '.tag_name' "$GITHUB_JSON")" = "v${RELEASE_VERSION}"
+if [[ "$RELEASE_VERSION" =~ (a|b|rc)[0-9]+$ ]]; then
+  jq --exit-status '.prerelease == true' "$GITHUB_JSON"
+else
+  jq --exit-status '.prerelease == false' "$GITHUB_JSON"
+fi
+
+for runtime in \
+  '12|docker.io/pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime' \
+  '13|docker.io/pytorch/pytorch:2.9.1-cuda13.0-cudnn9-runtime'; do
+  IFS='|' read -r cuda_major image <<< "$runtime"
+  docker run --rm --pull missing \
+    --gpus device=0 \
+    --network host \
+    -e "http_proxy=$PROXY_URL" \
+    -e "https_proxy=$PROXY_URL" \
+    -e "TMS_RELEASE_VERSION=$RELEASE_VERSION" \
+    -e "TMS_CUDA_MAJOR=$cuda_major" \
+    -e "TMS_EXPECTED_PYTEST_SKIPS=$EXPECTED_PYTEST_SKIPS" \
+    -v "$REPOSITORY_ROOT/test:/release-tests:ro" \
+    -v "$REPOSITORY_ROOT/.claude/skills/tms-publish-release/scripts/pytest_skip_gate.py:/validation/pytest_skip_gate.py:ro" \
+    "$image" \
+    bash -lc '
+set -euxo pipefail
+python -c '\''import importlib.util; assert importlib.util.find_spec("torch_memory_saver") is None'\''
+python -m pip install --no-cache-dir pytest==8.3.5 nvidia-ml-py==12.570.86
+python -m pip install --no-cache-dir --pre --no-deps "torch-memory-saver==${TMS_RELEASE_VERSION}"
+python - <<'\''PY'\''
+from pathlib import Path
+import os
+import torch
+import torch_memory_saver
+
+cuda = torch.version.cuda
+name = torch.cuda.get_device_name(0)
+package_path = Path(torch_memory_saver.__file__)
+print(torch.__version__, cuda, torch.cuda.is_available(), name, package_path)
+assert cuda is not None and cuda.split(".", 1)[0] == os.environ["TMS_CUDA_MAJOR"]
+assert torch.cuda.is_available()
+assert "4090 D" in name or "4090D" in name
+assert "site-packages" in package_path.parts
+PY
+CUDA_RUNTIME_LIB="$(python -c '\''from pathlib import Path; import os, site; major=os.environ["TMS_CUDA_MAJOR"]; matches=[path for root in site.getsitepackages() for path in (Path(root) / "nvidia").glob(f"**/libcudart.so.{major}")]; assert matches, matches; print(":".join(sorted({str(path.parent) for path in matches})))'\'')"
+export LD_LIBRARY_PATH="${CUDA_RUNTIME_LIB}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+mkdir -p /validation/test
+cp -a /release-tests/examples /validation/test/examples
+cp /release-tests/test_configure_subprocess.py /release-tests/test_examples.py /release-tests/test_utils.py /validation/test/
+cd /validation
+CUDA_VISIBLE_DEVICES=0 timeout --signal=TERM --kill-after=30s 3600s python -m pytest -p pytest_skip_gate test -vv -ra
+'
+done

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include csrc/*.h
+include csrc/*.cpp

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ reinstall:
 
 .PHONY:clean
 clean:
-	rm -rf dist/*
+	rm -rf dist build torch_memory_saver.egg-info ./*.so
 
 .PHONY:build-wheel
 build-wheel:
@@ -44,8 +44,15 @@ build-xpu:
 
 .PHONY:build-sdist
 build-sdist:
-	# python3 -m build --no-isolation
-	python3 setup.py sdist --dist-dir=dist
+	docker run --rm \
+	  -e TMS_HOST_UID=$$(id -u) \
+	  -e TMS_HOST_GID=$$(id -g) \
+	  -v $(CURDIR):/app \
+	  $${TMS_PYTHON_BUILD_IMAGE:-python:3.11} \
+	  /bin/bash -c "pip install --no-cache-dir setuptools==75.0.0 \
+	  && cd /app \
+	  && TMS_CUDA_MAJOR=12 python setup.py sdist --dist-dir=dist \
+	  && chown -R \"\$${TMS_HOST_UID}:\$${TMS_HOST_GID}\" /app/dist /app/torch_memory_saver.egg-info"
 
 .PHONY:upload
 upload:

--- a/scripts/build_multi_cuda.sh
+++ b/scripts/build_multi_cuda.sh
@@ -34,9 +34,27 @@ fi
 CU12_WHEEL="${cu12_matches[0]}"
 CU13_WHEEL="${cu13_matches[0]}"
 
-python3 scripts/merge_cuda_wheels.py "${CU12_WHEEL}" "${CU13_WHEEL}" --out-dir dist
-
-# Remove the per-CUDA intermediates so dist/ contains only the merged wheel.
-rm -f "${CU12_WHEEL}" "${CU13_WHEEL}"
+TMS_HOST_UID="$(id -u)"
+TMS_HOST_GID="$(id -g)"
+TMS_MERGE_PLATFORM="linux/$(uname -m)"
+TMS_MERGE_PLATFORM="${TMS_MERGE_PLATFORM/linux\/x86_64/linux\/amd64}"
+docker run --rm \
+    --platform "${TMS_MERGE_PLATFORM}" \
+    -e TMS_HOST_UID="${TMS_HOST_UID}" \
+    -e TMS_HOST_GID="${TMS_HOST_GID}" \
+    -e TMS_CU12_WHEEL="/app/${CU12_WHEEL}" \
+    -e TMS_CU13_WHEEL="/app/${CU13_WHEEL}" \
+    -v "$(pwd):/app" \
+    "${TMS_PYTHON_BUILD_IMAGE:-python:3.11}" \
+    bash -c '
+        set -euo pipefail
+        python /app/scripts/merge_cuda_wheels.py "$TMS_CU12_WHEEL" "$TMS_CU13_WHEEL" --out-dir /app/dist
+        rm -f "$TMS_CU12_WHEEL" "$TMS_CU13_WHEEL"
+        for path in /app/dist /app/build /app/torch_memory_saver.egg-info; do
+            if [[ -e "$path" ]]; then
+                chown -R "$TMS_HOST_UID:$TMS_HOST_GID" "$path"
+            fi
+        done
+    '
 
 ls -la dist/

--- a/scripts/merge_cuda_wheels.py
+++ b/scripts/merge_cuda_wheels.py
@@ -96,6 +96,8 @@ def merge(input_wheels: list[Path], out_path: Path) -> None:
             if compat_name not in merged:
                 merged[compat_name] = merged[name]
 
+    _rewrite_wheel_tag(merged=merged, out_name=out_path.name)
+
     # Rebuild RECORD: one line per file, then the RECORD's own entry with empty hash/size.
     record_lines: list[str] = []
     for name, data in sorted(merged.items()):
@@ -109,6 +111,31 @@ def merge(input_wheels: list[Path], out_path: Path) -> None:
         for name, data in merged.items():
             zf.writestr(name, data)
         zf.writestr(record_name, record_bytes)
+
+
+def _rewrite_wheel_tag(*, merged: dict[str, bytes], out_name: str) -> None:
+    wheel_names = sorted(name for name in merged if name.endswith(".dist-info/WHEEL"))
+    if len(wheel_names) != 1:
+        raise SystemExit(
+            f"Expected exactly one WHEEL metadata file, found {wheel_names}."
+        )
+
+    filename_parts = out_name.removesuffix(".whl").rsplit("-", 3)
+    if len(filename_parts) != 4:
+        raise SystemExit(f"Could not parse compatibility tag from {out_name!r}.")
+    expected_tag = "-".join(filename_parts[-3:])
+
+    wheel_name = wheel_names[0]
+    lines = merged[wheel_name].decode("utf-8").splitlines()
+    tag_indexes = [
+        index for index, line in enumerate(lines) if line.startswith("Tag: ")
+    ]
+    if len(tag_indexes) != 1:
+        raise SystemExit(
+            f"Expected exactly one Tag entry in {wheel_name}, found {tag_indexes}."
+        )
+    lines[tag_indexes[0]] = f"Tag: {expected_tag}"
+    merged[wheel_name] = ("\n".join(lines) + "\n").encode("utf-8")
 
 
 def main() -> None:

--- a/setup.py
+++ b/setup.py
@@ -317,7 +317,7 @@ class build_ext_for_platform(build_platform_ext):
 
 setup(
     name='torch_memory_saver',
-    version='0.0.9.post1',
+    version='0.0.10b1',
     ext_modules=ext_modules,
     cmdclass={'build_ext': build_ext_for_platform},
     python_requires=">=3.9",

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2,6 +2,7 @@ import pytest
 from contextlib import nullcontext
 
 import multiprocessing
+import os
 import sys
 import traceback
 import torch
@@ -25,10 +26,15 @@ from examples import (
 
 # XPU only supports hook_mode='torch'
 _IS_XPU = is_xpu()
+_IS_LUPINE = os.environ.get("TMS_TEST_LUPINE") == "1"
 _HOOK_MODES = ["torch"] if _IS_XPU else ["preload", "torch"]
 
 # Skip reason for tests that exercise CUDA/HIP-only paths on XPU.
 _skip_on_xpu = pytest.mark.skipif(_IS_XPU, reason="CUDA/HIP-only path, not supported on XPU")
+_skip_on_lupine = pytest.mark.skipif(
+    _IS_LUPINE,
+    reason="Lupine GPU-over-IP does not preserve native pinned-host or process RSS semantics",
+)
 _xpu_only = pytest.mark.skipif(not _IS_XPU, reason="XPU-specific path")
 _device_module = torch.xpu if _IS_XPU else torch.cuda
 _multi_device_only = pytest.mark.skipif(
@@ -85,6 +91,7 @@ def test_cpu_backup_backend_from_env(hook_mode):
 
 
 @_skip_on_xpu
+@_skip_on_lupine
 @pytest.mark.skipif(
     not torch.cuda.is_available()
     or torch.version.hip is not None
@@ -100,6 +107,7 @@ def test_cpu_backup_preload_backend_from_env():
         _test_core(cpu_backup.run_preload_backend_from_env, hook_mode="preload")
 
 
+@_skip_on_lupine
 @pytest.mark.parametrize("hook_mode", _HOOK_MODES)
 def test_disk_backup(hook_mode):
     _test_core(disk_backup.run, hook_mode=hook_mode)

--- a/test/test_merge_cuda_wheels.py
+++ b/test/test_merge_cuda_wheels.py
@@ -1,0 +1,97 @@
+import importlib.util
+import sys
+import zipfile
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_merge_cuda_wheels_module() -> ModuleType:
+    module_path = Path(__file__).parents[1] / "scripts" / "merge_cuda_wheels.py"
+    spec = importlib.util.spec_from_file_location("merge_cuda_wheels", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+merge_cuda_wheels = _load_merge_cuda_wheels_module()
+
+
+def test_merge_rewrites_internal_wheel_tag_to_match_output_filename(
+    tmp_path: Path,
+) -> None:
+    """Merged wheel metadata uses the compatibility tag from its final filename."""
+
+    cu12_wheel = tmp_path / (
+        "torch_memory_saver-0.0.10b1+cu128-cp39-abi3-manylinux2014_x86_64.whl"
+    )
+    cu13_wheel = tmp_path / (
+        "torch_memory_saver-0.0.10b1+cu130-cp39-abi3-manylinux2014_x86_64.whl"
+    )
+    _write_wheel(wheel_path=cu12_wheel, cuda_major="12")
+    _write_wheel(wheel_path=cu13_wheel, cuda_major="13")
+    output_path = tmp_path / (
+        "torch_memory_saver-0.0.10b1-cp39-abi3-manylinux2014_x86_64.whl"
+    )
+
+    merge_cuda_wheels.merge(
+        input_wheels=[cu12_wheel, cu13_wheel],
+        out_path=output_path,
+    )
+
+    with zipfile.ZipFile(output_path) as wheel:
+        wheel_metadata = wheel.read(
+            "torch_memory_saver-0.0.10b1.dist-info/WHEEL"
+        ).decode()
+    assert "Tag: cp39-abi3-manylinux2014_x86_64\n" in wheel_metadata
+    assert "Tag: cp39-abi3-linux_x86_64" not in wheel_metadata
+
+
+def test_merge_duplicates_cuda12_binaries_under_compatibility_names(
+    tmp_path: Path,
+) -> None:
+    """Unsuffixed legacy binaries are byte-identical CUDA 12 aliases."""
+
+    cu12_wheel = tmp_path / (
+        "torch_memory_saver-0.0.10b1+cu128-cp39-abi3-manylinux2014_x86_64.whl"
+    )
+    cu13_wheel = tmp_path / (
+        "torch_memory_saver-0.0.10b1+cu130-cp39-abi3-manylinux2014_x86_64.whl"
+    )
+    _write_wheel(wheel_path=cu12_wheel, cuda_major="12")
+    _write_wheel(wheel_path=cu13_wheel, cuda_major="13")
+    output_path = tmp_path / (
+        "torch_memory_saver-0.0.10b1-cp39-abi3-manylinux2014_x86_64.whl"
+    )
+
+    merge_cuda_wheels.merge(
+        input_wheels=[cu12_wheel, cu13_wheel],
+        out_path=output_path,
+    )
+
+    with zipfile.ZipFile(output_path) as wheel:
+        for hook_mode in ("preload", "torch"):
+            compatibility = wheel.read(
+                f"torch_memory_saver_hook_mode_{hook_mode}.abi3.so"
+            )
+            cuda12 = wheel.read(
+                f"torch_memory_saver_hook_mode_{hook_mode}_cu12.abi3.so"
+            )
+            assert compatibility == cuda12 == b"12"
+
+
+def _write_wheel(*, wheel_path: Path, cuda_major: str) -> None:
+    metadata_root = "torch_memory_saver-0.0.10b1.dist-info"
+    with zipfile.ZipFile(wheel_path, mode="w") as wheel:
+        wheel.writestr(
+            f"{metadata_root}/WHEEL",
+            "Wheel-Version: 1.0\nTag: cp39-abi3-linux_x86_64\n",
+        )
+        for hook_mode in ("preload", "torch"):
+            wheel.writestr(
+                f"torch_memory_saver_hook_mode_{hook_mode}_cu{cuda_major}.abi3.so",
+                cuda_major.encode(),
+            )
+        wheel.writestr(f"{metadata_root}/RECORD", "")


### PR DESCRIPTION
## Summary

- Add the repository-local `tms-publish-release` skill for beta and stable releases.
- Build final x86_64 and aarch64 wheels containing CUDA 12, CUDA 13, and unsuffixed CUDA 12 compatibility binaries.
- Validate those final wheels in four fresh GPU cells: direct x86_64 CUDA 12/13 and ARM64 CUDA 12/13 through digest-pinned Lupine workers.
- Keep upload, tag creation, and GitHub Release creation behind explicit human approval.

## Scope

- Base this PR directly on `master`.
- Keep `csrc/` unchanged.
- Exclude the closed #102 and #103 runtime fixes.
- Set `TMS_TEST_LUPINE=1` only in ARM64 validation.
- Mark only `test_cpu_backup_preload_backend_from_env` and both `test_disk_backup` parameters as Lupine-specific skips; keep both behaviors covered by direct x86_64 cells.

## Validation contract

- Install each already-final wheel into a fresh container and run runtime tests from `/validation`, outside the source checkout.
- Require the exact expected pytest skipped-node and normalized-reason map in every cell. Missing, extra, duplicate, or reason-changed skips fail the cell; CLI deselection is forbidden.
- Validate the exact distribution set, wheel metadata and ELF architecture, CUDA binary families, sdist sources, and every wheel `RECORD` member, SHA-256 digest, and size.
- Record every harness command, complete stdout/stderr, terminal result, image identity, environment, installed paths, loaded binaries, pytest output, and Lupine server logs.
- Preserve the primary validation failure if cleanup times out or cannot start, continue all remaining cleanup attempts, and fail an otherwise passing cell on an orchestration cleanup exception.
- Require every repository shell script, harness-owned inline shell, documented Bash block, and nested SSH/zsh shell to enable `set -euxo pipefail` before doing work.

## Human and publication gates

- Archive preflight, build, artifact, four-cell GPU, and local-recheck logs under one unique run directory.
- Generate a non-overwritable `artifacts.sha256` manifest only after the final artifact and Twine gates pass.
- Write a Markdown report linking all raw evidence and transcribing the three approved artifact hashes.
- Run one `release_checks.py pre-upload` command immediately before publication. It checks clean exact source identity, setup version, the approved manifest, the complete artifact gate, Twine, and all release namespaces in one log.
- Keep upload itself outside every release script.

## Post-release verification

- Keep Chapter 9 as the auditable `verify_published_release.sh` workflow instead of Python orchestration.
- Match the three published PyPI files and SHA-256 digests to the approved manifest and verify the GitHub Release tag/prerelease state.
- Start fresh CUDA 12 and CUDA 13 `--rm` containers, prove TMS is absent, install the exact published version from PyPI, prove the import resolves from `site-packages`, and run the complete runtime pytest suite with the exact skip gate.
- Save the complete shell trace and terminal result in `verify-published-release.log`.

## Verification

- `75 passed`: release checks, pre-upload gate, GPU harness, shell contracts, post-release workflow, skip gate, and merge-wheel UT.
- Bash syntax passed for every repository and release-workflow shell script.
- Ruff 0.16.3 format and lint passed on all changed Python tooling.
- Test-weakening review found no removed or relaxed assertion, skip, or coverage path.
- The four-cell 4090D GPU matrix and Chapter 9 post-release containers have not been run for this head; execution remains intentionally deferred until review.

## Safety

- No artifact was uploaded to PyPI.
- No release tag was created or pushed.
- No GitHub Release was created.

Lupine qualifies ARM user-space GPU behavior through an RPC shim to the physical 4090D. It does not certify an ARM NVIDIA kernel driver or native ARM PCIe path.