### PR TITLE
Use pageable staging for disk backups

### DIFF
--- a/csrc/disk_backend.cpp
+++ b/csrc/disk_backend.cpp
@@ -86,9 +86,8 @@ DiskBackend::DiskBackend(std::string dir, size_t chunk_bytes)
     : dir_(std::move(dir)), chunk_bytes_(chunk_bytes) {}
 
 void DiskBackend::ensure_staging_buf_() {
-    if (staging_buf_ == nullptr) {
-        CUDA_ERROR_CHECK(cudaMallocHost(&staging_buf_, chunk_bytes_));
-        SIMPLE_CHECK(staging_buf_ != nullptr, "failed to allocate pinned disk staging buffer");
+    if (staging_buf_.empty()) {
+        staging_buf_.resize(chunk_bytes_);
     }
 }
 
@@ -139,7 +138,7 @@ int DiskBackend::open_slot_file_(const DiskBackupSlot& slot) {
 void DiskBackend::offload(void* gpu_ptr, size_t size, DiskBackupSlot& slot) {
     ensure_staging_buf_();
     int fd = slot.path.empty() ? create_slot_file_(slot, size) : open_slot_file_(slot);
-    stream_chunked(fd, gpu_ptr, size, staging_buf_, chunk_bytes_, /*to_disk=*/true);
+    stream_chunked(fd, gpu_ptr, size, staging_buf_.data(), chunk_bytes_, /*to_disk=*/true);
     drop_page_cache(fd, size);
     close(fd);
 }
@@ -148,7 +147,8 @@ void DiskBackend::onload(void* gpu_ptr, size_t size, DiskBackupSlot& slot) {
     ensure_staging_buf_();
     SIMPLE_CHECK(!slot.path.empty(), "disk backup missing on resume (was it ever paused?)");
     int fd = open_slot_file_(slot);
-    stream_chunked(fd, gpu_ptr, size, staging_buf_, chunk_bytes_, /*to_disk=*/false);
+    stream_chunked(fd, gpu_ptr, size, staging_buf_.data(), chunk_bytes_, /*to_disk=*/false);
+    CUDA_ERROR_CHECK(cudaDeviceSynchronize());
     drop_page_cache(fd, size);
     close(fd);
 }

--- a/csrc/disk_backend.h
+++ b/csrc/disk_backend.h
@@ -2,13 +2,14 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 struct DiskBackupSlot {
     std::string path;
 };
 
 // Spills paused GPU allocations to per-allocation files, streaming through one
-// shared pinned staging buffer. dir_ must be a real disk mount, not tmpfs.
+// shared staging buffer. dir_ must be a real disk mount, not tmpfs.
 class DiskBackend {
 public:
     DiskBackend(std::string dir, size_t chunk_bytes);
@@ -27,7 +28,7 @@ private:
 
     std::string dir_;
     size_t chunk_bytes_;
-    void* staging_buf_ = nullptr;
+    std::vector<uint8_t> staging_buf_;
     bool checked_fs_ = false;
 };
 


### PR DESCRIPTION
## Summary

- Replace pinned `cudaMallocHost` disk-backup staging with a reusable pageable byte buffer.
- Synchronize pageable host-to-device restores before the buffer is reused.
- Keep the change backend-local and preserve the existing disk-backup API.

## Why

- GPU-forwarding runtimes may protect pinned host allocations for dirty tracking.
- A kernel `pread` into a read-only pinned mapping returns `EFAULT`; pageable staging remains writable.

## Testing

- Native RTX 4090 D regression: `2 passed in 2.88s` for `test_disk_backup` in the official PyTorch CUDA 12.4 development image.
- The same source delta passed the complete four-cell release matrix: x86_64 CUDA 12/13 and aarch64 CUDA 12/13 through Lupine, each with `31 passed, 11 skipped`.
- No tests were added, changed, weakened, or skipped as part of this extraction.

## Stack

- This is the first PR in the chain.
- The allocation-device fix follows in a separate PR.
- The release workflow remains in #101.
