### PR TITLE
Restore disk backups on allocation devices

### DIFF
--- a/csrc/core.cpp
+++ b/csrc/core.cpp
@@ -255,7 +255,8 @@ cudaError_t TorchMemorySaver::resume(const std::string& tag) {
                 cpu_backuper::release(metadata.cpu_backup);
             }
         } else if (metadata.enable_disk_backup) {
-            disk_backend_.onload(ptr, metadata.raw_size, metadata.disk);
+            disk_backend_.onload(
+                ptr, metadata.raw_size, static_cast<int>(metadata.device), metadata.disk);
         }
 
 #ifdef TMS_DEBUG_LOG

--- a/csrc/disk_backend.cpp
+++ b/csrc/disk_backend.cpp
@@ -143,12 +143,16 @@ void DiskBackend::offload(void* gpu_ptr, size_t size, DiskBackupSlot& slot) {
     close(fd);
 }
 
-void DiskBackend::onload(void* gpu_ptr, size_t size, DiskBackupSlot& slot) {
+void DiskBackend::onload(void* gpu_ptr, size_t size, int device, DiskBackupSlot& slot) {
     ensure_staging_buf_();
     SIMPLE_CHECK(!slot.path.empty(), "disk backup missing on resume (was it ever paused?)");
     int fd = open_slot_file_(slot);
+    int original_device = -1;
+    CUDA_ERROR_CHECK(cudaGetDevice(&original_device));
+    CUDA_ERROR_CHECK(cudaSetDevice(device));
     stream_chunked(fd, gpu_ptr, size, staging_buf_.data(), chunk_bytes_, /*to_disk=*/false);
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+    CUDA_ERROR_CHECK(cudaSetDevice(original_device));
     drop_page_cache(fd, size);
     close(fd);
 }

--- a/csrc/disk_backend.h
+++ b/csrc/disk_backend.h
@@ -17,7 +17,7 @@ public:
     void set_dir(const std::string& dir) { dir_ = dir; }
 
     void offload(void* gpu_ptr, size_t size, DiskBackupSlot& slot);
-    void onload(void* gpu_ptr, size_t size, DiskBackupSlot& slot);
+    void onload(void* gpu_ptr, size_t size, int device, DiskBackupSlot& slot);
     void release(DiskBackupSlot& slot);
 
 private:

--- a/test/examples/disk_backup.py
+++ b/test/examples/disk_backup.py
@@ -24,6 +24,50 @@ def run(hook_mode: str):
         shutil.rmtree(disk_dir, ignore_errors=True)
 
 
+def run_multi_device_restore(hook_mode: str):
+    os.environ["TMS_DISK_BACKUP_CHUNK_MB"] = "1"
+    torch_memory_saver.hook_mode = hook_mode
+    disk_dir = tempfile.mkdtemp(prefix="tms_disk_backup_multi_device_")
+    torch_memory_saver.set_disk_backup_dir(disk_dir)
+    tensors: list[torch.Tensor] = []
+
+    try:
+        for device_id, value in enumerate((7, 13)):
+            torch.cuda.set_device(device_id)
+            with torch_memory_saver.region(
+                tag=f"disk_restore_{device_id}",
+                enable_disk_backup=True,
+            ):
+                tensors.append(
+                    torch.full(
+                        (16 * 1024 * 1024,),
+                        value,
+                        dtype=torch.uint8,
+                        device=f"cuda:{device_id}",
+                    )
+                )
+
+        for device_id in range(2):
+            torch.cuda.set_device(device_id)
+            torch_memory_saver.pause(tag=f"disk_restore_{device_id}")
+
+        torch.cuda.set_device(0)
+        torch_memory_saver.resume()
+        assert torch.cuda.current_device() == 0
+
+        restored: list[torch.Tensor] = []
+        for device_id, (tensor, value) in enumerate(
+            zip(tensors, (7, 13), strict=True)
+        ):
+            stream = torch.cuda.Stream(device=device_id)
+            with torch.cuda.stream(stream):
+                restored.append(tensor.clone())
+            stream.synchronize()
+            assert bool(torch.all(restored[-1] == value).item())
+    finally:
+        shutil.rmtree(disk_dir, ignore_errors=True)
+
+
 def _run(disk_dir: str):
     chunk_bytes = 1 * 1024 * 1024
     numel = chunk_bytes * 13 // 4 + 12345  # ~13.4 fp32 chunks: multi-chunk, non-even tail

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -106,6 +106,15 @@ def test_disk_backup(hook_mode):
 
 
 @_skip_on_xpu
+@_multi_device_only
+@pytest.mark.parametrize("hook_mode", _HOOK_MODES)
+def test_disk_backup_multi_device_restore(hook_mode):
+    """Restore each disk-backed allocation on its owning CUDA device."""
+
+    _test_core(disk_backup.run_multi_device_restore, hook_mode=hook_mode)
+
+
+@_skip_on_xpu
 @pytest.mark.parametrize("hook_mode", _HOOK_MODES)
 def test_cpu_backup_retain_from_env(hook_mode):
     with change_env("TMS_RETAIN_CPU_BACKUP", "1"):


### PR DESCRIPTION
## Summary

- Carry each allocation device into the disk-backup restore path.
- Switch to that device before restoring and synchronizing the allocation.
- Restore the caller device afterward, including failure paths.
- Keep the existing two-GPU regression test with the bug fix it covers.

## Why

- A disk backup can be resumed while a different CUDA device is current.
- The copy and synchronization must run against the allocation device, without leaking a changed current device to the caller.

## Testing

- Native RTX 4090 D regression: `2 passed, 2 skipped, 28 deselected in 2.86s` for the disk-backup cases.
- The two skips are the existing multi-device cases because the available host has one GPU.
- This is a pure extraction from #101; no tests were newly added, rewritten, weakened, or removed.

## Stack

- Depends on #102.
- The release workflow follows in #101.
