### PR TITLE
[AMD] Align HIP VMM allocation sizes to allocation granularity (#82 counterpart)

### DIFF
--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -78,12 +78,18 @@ namespace CUDAUtils {
             return ans;
         }
 
-        static cudaError_t cu_mem_create(CUmemGenericAllocationHandle *alloc_handle, size_t allocation_size, CUdevice device) {
+        static hipMemAllocationProp cu_mem_get_allocation_prop(CUdevice device) {
             hipMemAllocationProp prop = {};
             prop.type = hipMemAllocationTypePinned;
             prop.location.type = hipMemLocationTypeDevice;
             prop.location.id = device;
             prop.allocFlags.compressionType = 0x0;
+
+            return prop;
+        }
+
+        static cudaError_t cu_mem_create(CUmemGenericAllocationHandle *alloc_handle, size_t allocation_size, CUdevice device) {
+            const hipMemAllocationProp prop = cu_mem_get_allocation_prop(device);
 
             hipError_t ret = hipMemCreate(alloc_handle, allocation_size, &prop, 0);
             if (ret == hipErrorOutOfMemory) {
@@ -96,8 +102,15 @@ namespace CUDAUtils {
         }
 
         static size_t cu_mem_get_allocation_size(size_t raw_size, CUdevice device) {
-            (void)device;
-            return raw_size;
+            const hipMemAllocationProp prop = cu_mem_get_allocation_prop(device);
+            size_t granularity = 0;
+            CURESULT_CHECK(hipMemGetAllocationGranularity(
+                &granularity, &prop, hipMemAllocationGranularityMinimum));
+            SIMPLE_CHECK(granularity > 0, "hipMemGetAllocationGranularity returned zero");
+            SIMPLE_CHECK(
+                raw_size <= std::numeric_limits<size_t>::max() - (granularity - 1),
+                "allocation size overflow while applying HIP VMM granularity");
+            return ((raw_size + granularity - 1) / granularity) * granularity;
         }
 
         static void cu_mem_set_access(void *ptr, size_t allocation_size, CUdevice device) {


### PR DESCRIPTION
## Problem

#82 added VMM allocation-granularity rounding for CUDA — `cu_mem_get_allocation_size` queries `cuMemGetAllocationGranularity` and rounds the requested size up — but the ROCm branch of the same hook was left as a passthrough (`csrc/utils.h`: `(void)device; return raw_size;`). This gap was flagged in #82's own review ("Align the ROCm >= 7 VMM path as well", citing AMD's HIP VMM guide) and did not make the merged version.

On ROCm the passthrough has always violated the documented contract: `hipMemCreate` has rejected sizes not aligned to `memBaseAddrAlign_` since its first implementation (ROCm 5.2), and ROCm 10 additionally validates `hipMemMap` sizes against `hipMemAllocationGranularityMinimum` (ROCm/rocm-systems#6982, first shipped in the HIP 7.14/7.15 line). A minimal standalone probe on MI355X / ROCm 10.0:

- `hipMemGetAllocationGranularity(..., Minimum)` → 4096
- `hipMemCreate(size=6912)` → error 1 (invalid argument)
- `hipMemCreate(size=8192)` → success; the full reserve / map / set-access / unmap / release / re-create lifecycle is clean at aligned sizes

In practice torch_memory_saver forwards unaligned request sizes unchanged (6912 bytes in our runs, under `memory_margin_bytes` colocate setups), which crashes every Megatron actor at init on ROCm 10:

    [torch_memory_saver.cpp] CUresult error: 1 (invalid argument) file=csrc/utils.h func=cu_mem_create line=93

## Fix

Mirror the CUDA implementation from #82 on the HIP branch:

- extract `cu_mem_get_allocation_prop` so `cu_mem_create` and the granularity query share one `hipMemAllocationProp`
- implement `cu_mem_get_allocation_size`: query `hipMemGetAllocationGranularity(..., hipMemAllocationGranularityMinimum)`, guard zero granularity and `size_t` overflow, round up

No CUDA-path changes. No behavior change on ROCm runtimes whose granularity already divides the requested sizes (the rounded size equals the raw size there).

## Validation

All on MI355X / ROCm 10.0 / torch 2.11.0+rocm10.

- the regression test added in #82 is already platform-aware (`prefix = "hip" if torch.version.hip else "cuda"`), so no new test files are needed. On master it fails with exactly the bug signature (`CUresult error: 1 (invalid argument) func=cu_mem_create line=93`); with this change it passes — first time this test goes green on ROCm.
- full test suite with the change: `3 failed, 24 passed, 15 skipped`. The same 3 tests (`test_cpu_backup_retain_from_env[preload|torch]`, `test_training_engine`) fail identically on unpatched master — pre-existing ROCm CPU-backup gaps, untouched by this change.
- standalone HIP probe above (granularity=4096, create(6912)→error 1, create(8192)→clean lifecycle)
- end-to-end: the 7 Megatron colocate CI tests that previously crashed with this signature all pass with the change applied on top of `f05a875` (rocm nightly stage-c suites, 8×MI355X)
- ROCm 7.2: behavior unchanged